### PR TITLE
Make synchronous value typeahead suggestions filter case insensitive

### DIFF
--- a/lib/cql/src/lang/fixtures/TestTypeaheadHelpers.ts
+++ b/lib/cql/src/lang/fixtures/TestTypeaheadHelpers.ts
@@ -1,13 +1,33 @@
 import { TypeaheadField } from "../typeahead";
 import { TextSuggestionOption } from "../types";
 
+export const testTags = [
+  new TextSuggestionOption("Tags are magic", "tags-are-magic", "A magic tag"),
+  new TextSuggestionOption(
+    "Tag with a space in it",
+    "Tag with space",
+    "A tag with whitespace in the id. Gosh",
+  ),
+  new TextSuggestionOption(
+    "abc DEF",
+    "GHI jkl",
+    "A tag with a mix of upper and lowercase strings",
+  ),
+];
+
 export class TestTypeaheadHelpers {
   public typeaheadFields = [
     new TypeaheadField(
       "tag",
       "Tag",
       "Search by content tags, e.g. sport/football",
-      this.getTags,
+      this.getAsyncTags,
+    ),
+    new TypeaheadField(
+      "sync",
+      "Sync",
+      "Search synchronous list of tags",
+      testTags,
     ),
     new TypeaheadField(
       "section",
@@ -24,19 +44,8 @@ export class TestTypeaheadHelpers {
     ),
   ];
 
-  private getTags(): Promise<TextSuggestionOption[]> {
-    return Promise.resolve([
-      new TextSuggestionOption(
-        "Tags are magic",
-        "tags-are-magic",
-        "A magic tag",
-      ),
-      new TextSuggestionOption(
-        "Tag with a space in it",
-        "Tag with space",
-        "A tag with whitespace in the id. Gosh",
-      ),
-    ]);
+  private getAsyncTags(): Promise<TextSuggestionOption[]> {
+    return Promise.resolve(testTags);
   }
 
   private getSections(): Promise<TextSuggestionOption[]> {

--- a/lib/cql/src/lang/typeahead.spec.ts
+++ b/lib/cql/src/lang/typeahead.spec.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "bun:test";
 import { Typeahead } from "./typeahead";
-import { DateSuggestionOption, TextSuggestionOption } from "./types";
-import { TestTypeaheadHelpers } from "./fixtures/TestTypeaheadHelpers";
+import {
+  DateSuggestionOption,
+  TextSuggestionOption,
+  TypeaheadSuggestion,
+} from "./types";
+import {
+  testTags,
+  TestTypeaheadHelpers,
+} from "./fixtures/TestTypeaheadHelpers";
 import { createParser } from "./Cql";
 
 describe("typeahead", () => {
@@ -24,6 +31,11 @@ describe("typeahead", () => {
             "Tag",
             "tag",
             "Search by content tags, e.g. sport/football",
+          ),
+          new TextSuggestionOption(
+            "Sync",
+            "sync",
+            "Search synchronous list of tags",
           ),
           new TextSuggestionOption(
             "Section",
@@ -84,22 +96,65 @@ describe("typeahead", () => {
         from: 4,
         to: 18,
         position: "chipValue",
+        suggestions: testTags,
+        type: "TEXT",
+        suffix: " ",
+      },
+    ]);
+  });
+
+  it("should give typeahead suggestions in a case insensitive way for synchronous query meta keys across value and label", async () => {
+    const expectedSuggestions: TypeaheadSuggestion[] = [
+      {
+        from: 0,
+        position: "chipKey",
+        suffix: ":",
         suggestions: [
           new TextSuggestionOption(
-            "Tags are magic",
-            "tags-are-magic",
-            "A magic tag",
+            "Sync",
+            "sync",
+            "Search synchronous list of tags",
           ),
+        ],
+        to: 4,
+        type: "TEXT",
+      },
+      {
+        from: 5,
+        to: 8,
+        position: "chipValue",
+        suggestions: [
           new TextSuggestionOption(
-            "Tag with a space in it",
-            "Tag with space",
-            "A tag with whitespace in the id. Gosh",
+            "abc DEF",
+            "GHI jkl",
+            "A tag with a mix of upper and lowercase strings",
           ),
         ],
         type: "TEXT",
         suffix: " ",
       },
-    ]);
+    ];
+
+    const suggestionsUppercaseLabelQuery = await getSuggestions("+sync:ABC");
+
+    expect(suggestionsUppercaseLabelQuery).toEqual(expectedSuggestions);
+
+    const suggestionsLowercaseLabelQuery = await getSuggestions("+sync:def");
+
+    expect(suggestionsLowercaseLabelQuery).toEqual(expectedSuggestions);
+
+    const suggestionsUppercaseValueQuery = await getSuggestions("+sync:JKL");
+
+    expect(suggestionsUppercaseValueQuery).toEqual(expectedSuggestions);
+
+    const suggestionsLowercaseValueQuery = await getSuggestions("+sync:ghi");
+
+    expect(suggestionsLowercaseValueQuery).toEqual(expectedSuggestions);
+
+    const suggestionsForNonMatchingQuery = await getSuggestions("+sync:mno");
+    expect(suggestionsLowercaseValueQuery).not.toEqual(
+      suggestionsForNonMatchingQuery,
+    );
   });
 
   it("should give value suggestions for an empty string", async () => {
@@ -123,18 +178,7 @@ describe("typeahead", () => {
         from: 4,
         to: 4,
         position: "chipValue",
-        suggestions: [
-          new TextSuggestionOption(
-            "Tags are magic",
-            "tags-are-magic",
-            "A magic tag",
-          ),
-          new TextSuggestionOption(
-            "Tag with a space in it",
-            "Tag with space",
-            "A tag with whitespace in the id. Gosh",
-          ),
-        ],
+        suggestions: testTags,
         type: "TEXT",
         suffix: " ",
       },
@@ -198,18 +242,7 @@ describe("typeahead", () => {
         from: 4,
         to: 5,
         position: "chipValue",
-        suggestions: [
-          new TextSuggestionOption(
-            "Tags are magic",
-            "tags-are-magic",
-            "A magic tag",
-          ),
-          new TextSuggestionOption(
-            "Tag with a space in it",
-            "Tag with space",
-            "A tag with whitespace in the id. Gosh",
-          ),
-        ],
+        suggestions: testTags,
         type: "TEXT",
         suffix: " ",
       },
@@ -222,6 +255,11 @@ describe("typeahead", () => {
             "Tag",
             "tag",
             "Search by content tags, e.g. sport/football",
+          ),
+          new TextSuggestionOption(
+            "Sync",
+            "sync",
+            "Search synchronous list of tags",
           ),
           new TextSuggestionOption(
             "Section",

--- a/lib/cql/src/lang/typeahead.ts
+++ b/lib/cql/src/lang/typeahead.ts
@@ -12,6 +12,17 @@ type TypeaheadResolver =
   | ((str: string, signal?: AbortSignal) => Promise<TextSuggestionOption[]>)
   | TextSuggestionOption[];
 
+function filterTextSuggestionOption(
+  suggestions: TextSuggestionOption[],
+  str: string,
+) {
+  return suggestions.filter(
+    (_) =>
+      _.value.toLowerCase().includes(str.toLowerCase()) ||
+      _.label.toLowerCase().includes(str.toLowerCase()),
+  );
+}
+
 export class TypeaheadField {
   constructor(
     public id: string,
@@ -26,9 +37,7 @@ export class TypeaheadField {
     signal?: AbortSignal,
   ): Promise<TextSuggestionOption[]> | undefined {
     if (Array.isArray(this.resolver)) {
-      return Promise.resolve(
-        this.resolver.filter((item) => item.label.includes(str)),
-      );
+      return Promise.resolve(filterTextSuggestionOption(this.resolver, str));
     }
 
     return this.resolver?.(str, signal);
@@ -135,8 +144,9 @@ export class Typeahead {
       return this.typeaheadFieldEntries;
     }
 
-    const suggestions = this.typeaheadFieldEntries.filter((_) =>
-      _.value.includes(str.toLowerCase()),
+    const suggestions = filterTextSuggestionOption(
+      this.typeaheadFieldEntries,
+      str,
     );
 
     if (suggestions.length) {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This PR changes the way typeahead suggestions for synchronous chip values (ie ones that are statically defined in the code) are filtered, to make it case insensitive. It also searches across both value and label. This same logic now applies to the chip key as well.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

This PR adds a new test that tests a mock "sync" typeahead field with a mix of cases in the suggestion options.

More a manual test test the "production-office" key and see the before and after.

| Before | After |
| -- | -- |
| ![image](https://github.com/user-attachments/assets/0ce24512-8771-4f72-afa9-b67951999e6c) |   ![image](https://github.com/user-attachments/assets/bb8006a1-9b8c-4100-973c-439225565c20) |

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
