### PR TITLE
Make typeahead suggestion label optional

### DIFF
--- a/.changeset/sharp-beans-call.md
+++ b/.changeset/sharp-beans-call.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Make the typeahead suggestion label optional

--- a/.changeset/sharp-beans-call.md
+++ b/.changeset/sharp-beans-call.md
@@ -3,3 +3,4 @@
 ---
 
 Make the typeahead suggestion label optional
+Makes typehead searches case insensitive, where the search is through a static list of values

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -275,7 +275,8 @@ export const createCqlInput = (
           }
 
           .Cql__Option--is-selected {
-            background-color: rgba(255,255,255,0.1);
+            background-color: ${typeahead.selectedOption.color.background};
+            color: ${typeahead.selectedOption.color.text};
           }
 
           .Cql__Option--is-disabled {
@@ -285,7 +286,8 @@ export const createCqlInput = (
           }
 
           .Cql__Option:hover {
-            background-color: rgba(255,255,255,0.2);
+            background-color: ${typeahead.hover.color.background};
+            color: ${typeahead.hover.color.text};
             cursor: pointer;
           }
 

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -94,14 +94,16 @@ export const TextSuggestionContent = ({
                 onClick={() => onSelect(value)}
               >
                 <div class="Cql__OptionLabel">
-                  {label}
+                  {label ?? value}
                   {showCount && count !== undefined && (
                     <div class="Cql__OptionCount">
                       {numberFormat.format(count)}
                     </div>
                   )}
                 </div>
-                {showValue && <div class="Cql__OptionValue">{value}</div>}
+                {showValue && label !== undefined && (
+                  <div class="Cql__OptionValue">{value}</div>
+                )}
                 {showDescription && description && (
                   <div class="Cql__OptionDescription">{description}</div>
                 )}

--- a/lib/cql/src/cqlInput/theme.ts
+++ b/lib/cql/src/cqlInput/theme.ts
@@ -32,6 +32,18 @@ export type CqlTheme = {
     layout: {
       width: string;
     };
+    selectedOption: {
+      color: {
+        background: string;
+        text: string;
+      };
+    };
+    hover: {
+      color: {
+        background: string;
+        text: string;
+      };
+    };
   };
   tokens: {
     color: {
@@ -74,6 +86,18 @@ const defaultTheme: CqlTheme = {
   typeahead: {
     layout: {
       width: "400px",
+    },
+    selectedOption: {
+      color: {
+        background: "rgba(255,255,255,0.1)",
+        text: "#eee",
+      },
+    },
+    hover: {
+      color: {
+        background: "rgba(255,255,255,0.2)",
+        text: "#eee",
+      },
     },
   },
   tokens: {

--- a/lib/cql/src/lang/typeahead.ts
+++ b/lib/cql/src/lang/typeahead.ts
@@ -20,7 +20,7 @@ function filterTextSuggestionOption(
   return suggestions.filter(
     (_) =>
       _.value.toLowerCase().includes(lowerCaseStr) ||
-      _.label.toLowerCase().includes(lowerCaseStr),
+      _.label?.toLowerCase().includes(lowerCaseStr),
   );
 }
 

--- a/lib/cql/src/lang/types.ts
+++ b/lib/cql/src/lang/types.ts
@@ -29,7 +29,7 @@ type SuggestionTypeMap = {
 
 export class TextSuggestionOption {
   public constructor(
-    public readonly label: string,
+    public readonly label: string | undefined,
     public readonly value: string,
     public readonly description?: string,
     public readonly count?: number,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Makes the typeahead suggestion label for chip values optional*. This means where there isn't a suitable label we don't have to duplicate it. The value then takes the label's place.

*The type is now `string | undefined` so the consumer has to explicitly give undefined, this was the lazy solution to not change every calling site.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Remove a label from one of the typeahead suggestions (eg in CapiTypeaheadHelpers) and see that the value is now the label. 

Or more pertinently run the Grid and remove the suggestion as a label.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

| Before | After |
| -- | -- |  
| ![image](https://github.com/user-attachments/assets/5964ade3-f991-4adb-8acc-16c5edb87279) | ![image](https://github.com/user-attachments/assets/55d0a5e4-fe65-4228-93be-e0952a5ab930) |  

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

