### PR TITLE
Add colour theming for typeahead option on select and hover

### DIFF
--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -275,7 +275,8 @@ export const createCqlInput = (
           }
 
           .Cql__Option--is-selected {
-            background-color: rgba(255,255,255,0.1);
+            background-color: ${typeahead.selectedOption.color.background};
+            color: ${typeahead.selectedOption.color.text};
           }
 
           .Cql__Option--is-disabled {
@@ -285,7 +286,8 @@ export const createCqlInput = (
           }
 
           .Cql__Option:hover {
-            background-color: rgba(255,255,255,0.2);
+            background-color: ${typeahead.hover.color.background};
+            color: ${typeahead.hover.color.text};
             cursor: pointer;
           }
 

--- a/lib/cql/src/cqlInput/theme.ts
+++ b/lib/cql/src/cqlInput/theme.ts
@@ -32,6 +32,18 @@ export type CqlTheme = {
     layout: {
       width: string;
     };
+    selectedOption: {
+      color: {
+        background: string;
+        text: string;
+      };
+    };
+    hover: {
+      color: {
+        background: string;
+        text: string;
+      };
+    };
   };
   tokens: {
     color: {
@@ -74,6 +86,18 @@ const defaultTheme: CqlTheme = {
   typeahead: {
     layout: {
       width: "400px",
+    },
+    selectedOption: {
+      color: {
+        background: "rgba(255,255,255,0.1)",
+        text: "#eee",
+      },
+    },
+    hover: {
+      color: {
+        background: "rgba(255,255,255,0.2)",
+        text: "#eee",
+      },
     },
   },
   tokens: {


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

Adds theming for typeahead dropdown options to control the text and background colours, for the hover and selected (ie with the keyboard) state. This means the grid can make selected options align with its styling.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Update the grid to use the new theming options and add a new chip, use the keyboard to access the "select" state and the mouse to hover.

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## Images

### Grid without CQL
<img width="410" alt="image" src="https://github.com/user-attachments/assets/12bfa8b6-f4b8-45b9-a5e7-add24629e3af" />

### Grid with CQL default theming
<img width="410" alt="image" src="https://github.com/user-attachments/assets/50327337-eb62-4943-be8b-72ef3b721511" />

### Grid theming select and hover to blue
<img width="403" alt="image" src="https://github.com/user-attachments/assets/4a7f0e56-7884-4737-902f-af9a297dd79b" />

### Grid theming only hover to blue 
(keyboard selection is on "Category")
<img width="401" alt="image" src="https://github.com/user-attachments/assets/2f8bfe69-0f72-49d4-ac07-5a2f88c5cf29" />

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Which is the right option?

Theming the select and hover states to the same colour, while both can display simultaneously, seems like it might have some accessibility/usability concerns. 

A potential solution might be to take the approach that the grid uses before - on mouse entry the keyboard selection position moves to the option that the mouse moved over. But this would require some extra work on the mouse entry event. See video below for how this works:

https://github.com/user-attachments/assets/e44a0f97-ee7c-497f-8aea-b756e4e848ed


