### PR TITLE
Fix CI out of `main`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,6 +37,7 @@ jobs:
     - name: Create Release Pull Request or Publish to npm
       id: changesets
       uses: changesets/action@v1
+      if: github.ref == 'refs/heads/main'
       with:
         title: "🦋 Release package updates"
         commit: "Bump package versions"
@@ -51,6 +52,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
 
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -86,6 +86,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      pull-requests: write
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/src/main/scala/Handler.scala
+++ b/src/main/scala/Handler.scala
@@ -1,10 +1,7 @@
 package cql
 
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
-import com.amazonaws.services.lambda.runtime.events.{
-  Step,
-  APIGatewayProxyResponseEvent
-}
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyResponseEvent
 import io.circe.syntax._
 import util.Logging
 
@@ -15,6 +12,7 @@ import scala.jdk.CollectionConverters._
 import scala.concurrent.Future
 import com.gu.contentapi.client.GuardianContentClient
 import cql.lang.{Cql, Typeahead, TypeaheadHelpersCapi}
+import com.amazonaws.services.lambda.runtime.events.APIGatewayProxyRequestEvent
 class Handler
     extends RequestHandler[
       APIGatewayProxyRequestEvent,


### PR DESCRIPTION
## What does this change?

Attempt to fix CI off `main` — 

- changesets should not be running
- the sandbox deploy should be able to write to the pull request.
- the Scala build should not fail

## How to test

All of those things should work ✅ on this branch.

