### PR TITLE
Alter dropdown selection index on hover

### DIFF
--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -351,7 +351,7 @@ export const createCqlInput = (
 
           .Cql__TypeaheadPopoverContainer, .Cql__ErrorPopover {
             position: absolute;
-            width: ${typeahead.layout.width};
+            min-width: ${typeahead.layout.minWidth};
             height: 100%;
             max-height: min(80vh, 400px);
             margin: 0;

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -286,8 +286,6 @@ export const createCqlInput = (
           }
 
           .Cql__Option:hover {
-            background-color: ${typeahead.hover.color.background};
-            color: ${typeahead.hover.color.text};
             cursor: pointer;
           }
 

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -364,6 +364,7 @@ export const createCqlInput = (
             display: flex;
             width: 100%;
             max-height: 100%;
+            padding: ${typeahead.layout.padding};
             font-size: ${baseFontSize};
             border-radius: ${baseBorderRadius};
             color: #eee;

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -92,6 +92,7 @@ export const TextSuggestionContent = ({
                 data-index={index}
                 ref={isSelected ? currentItemRef : null}
                 onClick={() => onSelect(value)}
+                onMouseEnter={() => setCurrentOptionIndex(index)}
               >
                 <div class="Cql__OptionLabel">
                   {label ?? value}

--- a/lib/cql/src/cqlInput/theme.ts
+++ b/lib/cql/src/cqlInput/theme.ts
@@ -31,6 +31,7 @@ export type CqlTheme = {
   typeahead: {
     layout: {
       minWidth: string;
+      padding: string;
     };
     selectedOption: {
       color: {
@@ -80,6 +81,7 @@ const defaultTheme: CqlTheme = {
   typeahead: {
     layout: {
       minWidth: "400px",
+      padding: "0",
     },
     selectedOption: {
       color: {

--- a/lib/cql/src/cqlInput/theme.ts
+++ b/lib/cql/src/cqlInput/theme.ts
@@ -38,12 +38,6 @@ export type CqlTheme = {
         text: string;
       };
     };
-    hover: {
-      color: {
-        background: string;
-        text: string;
-      };
-    };
   };
   tokens: {
     color: {
@@ -90,12 +84,6 @@ const defaultTheme: CqlTheme = {
     selectedOption: {
       color: {
         background: "rgba(255,255,255,0.1)",
-        text: "#eee",
-      },
-    },
-    hover: {
-      color: {
-        background: "rgba(255,255,255,0.2)",
         text: "#eee",
       },
     },

--- a/lib/cql/src/cqlInput/theme.ts
+++ b/lib/cql/src/cqlInput/theme.ts
@@ -30,7 +30,7 @@ export type CqlTheme = {
   };
   typeahead: {
     layout: {
-      width: string;
+      minWidth: string;
     };
     selectedOption: {
       color: {
@@ -79,7 +79,7 @@ const defaultTheme: CqlTheme = {
   },
   typeahead: {
     layout: {
-      width: "400px",
+      minWidth: "400px",
     },
     selectedOption: {
       color: {


### PR DESCRIPTION
## What does this change?

Alters the dropdown selection index on hover, removing the CSS hover styling that previously allowed selection and hover styling to differ. Also adds a few styling changes to align w/ Grid.

|Before|After|
|--|--|
|![hover-before](https://github.com/user-attachments/assets/53b888e1-5766-4d29-9a49-8405600af150)|![hover-after](https://github.com/user-attachments/assets/6edd34fd-17cc-4081-b31d-740f3e2b0ca8)|

## How to test

Observe the dropdown behaviour on this branch. Behave as expected?

Difficult to unit test, and unlikely to regress — we can revisit if that assumption is proven wrong.
