### PR TITLE
Add shortcuts

### DIFF
--- a/.changeset/chilly-bottles-cheat.md
+++ b/.changeset/chilly-bottles-cheat.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": minor
+---
+
+Parse shortcuts from query strings, and add chips when shortcuts are pressed in the UI

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -37,8 +37,6 @@ export const createCqlInput = (
   typeahead: Typeahead,
   config: CqlConfig = {
     syntaxHighlighting: true,
-    theme: {},
-    lang: {},
   },
 ) => {
   class CqlInput extends HTMLElement {

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -468,10 +468,9 @@ export const createCqlInput = (
             overflow-x: hidden;
             text-overflow: ellipsis;
             vertical-align: bottom;
-            /* Passes accessibility contrast on a white background */
-            color: #777575;
             pointer-events: none;
             cursor: text;
+            opacity: 0.8;
           }
         </style>
       `;

--- a/lib/cql/src/cqlInput/editor/commands.ts
+++ b/lib/cql/src/cqlInput/editor/commands.ts
@@ -1,10 +1,16 @@
-import { Command, Selection, TextSelection } from "prosemirror-state";
-import { chipValue } from "./schema";
+import {
+  Command,
+  NodeSelection,
+  Selection,
+  TextSelection,
+} from "prosemirror-state";
+import { chip, chipKey, chipValue } from "./schema";
 import { selectAll } from "prosemirror-commands";
 import { createParser } from "../../lang/Cql";
-import { queryToProseMirrorDoc } from "./utils";
+import { findNodeAt, queryToProseMirrorDoc } from "./utils";
 import { findDiffEndForContent, findDiffStartForContent } from "./diff";
 import { Node } from "prosemirror-model";
+import { schema } from "prosemirror-test-builder";
 
 export const startOfLine: Command = (state, dispatch) => {
   const startSelection = Selection.atStart(state.doc);
@@ -79,6 +85,26 @@ export const mergeDocs =
 
       dispatch?.(tr);
     }
+
+    return true;
+  };
+
+export const insertChip =
+  (chipKeyContent: string): Command =>
+  (state, dispatch) => {
+    const tr = state.tr;
+    const node = chip.create(null, [
+      chipKey.create(null, schema.text(chipKeyContent)),
+      chipValue.create(),
+    ]);
+
+    tr.replaceSelectionWith(node);
+
+    const chipValuePos = findNodeAt(state.selection.from, tr.doc, chipValue);
+    const sel = NodeSelection.create(tr.doc, chipValuePos);
+    tr.setSelection(sel);
+
+    dispatch?.(tr);
 
     return true;
   };

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -37,6 +37,7 @@ import {
   IS_READ_ONLY,
   IS_SELECTED,
   POLARITY,
+  queryStr,
 } from "../schema";
 import { Node } from "prosemirror-model";
 import { ErrorPopover } from "../../popover/ErrorPopover";
@@ -51,7 +52,7 @@ import { CqlQuery } from "../../../lang/ast";
 import { createParser } from "../../../lang/Cql";
 import { Typeahead } from "../../../lang/typeahead";
 import { defaultPopoverRenderer } from "../../popover/components/defaultPopoverRenderer";
-import { mergeDocs } from "../commands";
+import { insertChip, mergeDocs } from "../commands";
 
 const cqlPluginKey = new PluginKey<PluginState>("cql-plugin");
 
@@ -106,6 +107,7 @@ export const createCqlPlugin = ({
     syntaxHighlighting,
     debugEl,
     renderPopoverContent = defaultPopoverRenderer,
+    lang,
   },
   parser,
 }: {
@@ -593,6 +595,16 @@ export const createCqlPlugin = ({
               prevNode,
             );
           }
+        }
+
+        // Shortcuts
+        const $selFrom = view.state.selection.$from;
+        const isInQueryStr = $selFrom.node().type === queryStr;
+        if (lang?.shortcuts?.[event.key] && isInQueryStr) {
+          return insertChip(lang?.shortcuts?.[event.key])(
+            view.state,
+            view.dispatch,
+          );
         }
 
         // Typeahead-specific behaviours

--- a/lib/cql/src/cqlInput/editor/utils.ts
+++ b/lib/cql/src/cqlInput/editor/utils.ts
@@ -381,7 +381,7 @@ export const docToCqlStr = (doc: Node): string => {
   return str;
 };
 
-const findNodeAt = (pos: number, doc: Node, type: NodeType): number => {
+export const findNodeAt = (pos: number, doc: Node, type: NodeType): number => {
   let found = -1;
   doc.nodesBetween(pos - 1, doc.content.size, (node, pos) => {
     if (found > -1) return false;

--- a/lib/cql/src/lang/scanner.spec.ts
+++ b/lib/cql/src/lang/scanner.spec.ts
@@ -256,5 +256,33 @@ describe("scanner", () => {
         );
       });
     });
+
+    describe("shortcuts", () => {
+      it("should throw an error when a shortcut conflicts with a reserved character", () => {
+        const shouldThrow = () =>
+          new Scanner("", { shortcuts: { "(": "invalid" } });
+
+        expect(shouldThrow).toThrow();
+      });
+
+      it("should throw an error when a shortcut is more than a single character long", () => {
+        const shouldThrow = () =>
+          new Scanner("", { shortcuts: { aa: "invalid" } });
+
+        expect(shouldThrow).toThrow();
+      });
+
+      it("parse a shortcut followed by a chip value", () => {
+        assertTokens(
+          "#tone/news",
+          [
+            new Token(TokenType.CHIP_KEY_POSITIVE, "#", "tag", 0, 0),
+            new Token(TokenType.CHIP_VALUE, "#tone/news", "tone/news", 0, 9),
+            eofToken(10),
+          ],
+          { shortcuts: { "#": "tag" } },
+        );
+      });
+    });
   });
 });

--- a/lib/cql/src/page.ts
+++ b/lib/cql/src/page.ts
@@ -71,7 +71,12 @@ const CqlInputCapi = createCqlInput(capiTypeahead, {
   syntaxHighlighting: true,
   theme: {
     baseFontSize: "16px",
-  }
+  },
+  lang: {
+    shortcuts: {
+      "#": "tag",
+    },
+  },
 });
 
 const guToolsTypeaheadFields: TypeaheadField[] = [


### PR DESCRIPTION
## What does this change?

Adds shortcuts to create chips, declared in the configuration options. Shortcuts expand single characters into predefined chip keys, and when pressed, push the selection into value position. 

For example, adding `shortcuts: { "#": "tag" }` and typing `#` in the editor will add the chip `tag:`, and place the caret after the `:`.

This PR contains one of two ways I've attempted to solve this: it
 1. modifies the scanner to interpret shortcut characters as chip keys, storing them in the literal, which takes care of interpreting query strings correctly. This isn't enough to move the selection into the correct position as a result of inserting a chip, so the PR also:
 2. adds a command to add a chip when a user presses a shortcut key.

It's possible to solve the positioning problem another way when the user inserts a chip, by mapping the selection through the following steps (assuming shortcut `#` -> `tag:`, and `$` denotes caret position):
 - transform the query from document to query string: `<qs>#$</qs>` -> `#$`
 - expanding the query: `#$` -> `tag:$`
 - transform the query from query string to document: `<qs></qs><c><ck>tag</ck><cv>$</cv></c><qs></qs>`

I've attempted that on [this branch](https://github.com/guardian/cql/tree/jsh/shortcuts), but this approach adds up to code that cuts across lots of different concerns (doc to query str, token mapping, query str to doc), coupling them all in a way that I think will be confusing to maintain.

This PR is a little kludge-y in comparison, but solves both the parsing and the input cases in a way which is much simpler to reason about, for fewer LoC.

## How to test

- the tests should pass.
- have a play: shortcuts should work as expected

Tested in Grid.