### PR TITLE
Refactor: extract debug rendering from CqlInput

### DIFF
--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -1,25 +1,25 @@
 import { EditorView } from "prosemirror-view";
+import { createParser } from "../lang/Cql";
+import { cqlQueryStrFromQueryAst } from "../lang/interpreter";
+import { ScannerSettings } from "../lang/scanner";
+import { Typeahead } from "../lang/typeahead";
+import { CqlQuery } from "../lib";
 import { QueryChangeEventDetail } from "../types/dom";
+import { DeepPartial } from "../types/utils";
 import { createEditorView } from "./editor/editor";
 import {
-  createCqlPlugin,
-  CLASS_VISIBLE,
-  CLASS_CHIP_SELECTED,
   CLASS_CHIP_KEY_READONLY,
+  CLASS_CHIP_SELECTED,
+  CLASS_VISIBLE,
+  createCqlPlugin,
 } from "./editor/plugins/cql";
+import { CLASSNAME_PLACEHOLDER } from "./editor/plugins/placeholder";
 import {
   CLASS_NO_RESULTS,
   CLASS_PENDING,
   RenderPopoverContent,
 } from "./popover/TypeaheadPopover";
-import { Typeahead } from "../lang/typeahead";
 import { applyPartialTheme, CqlTheme } from "./theme";
-import { ScannerSettings } from "../lang/scanner";
-import { DeepPartial } from "../types/utils";
-import { createParser } from "../lang/Cql";
-import { cqlQueryStrFromQueryAst } from "../lang/interpreter";
-import { CLASSNAME_PLACEHOLDER } from "./editor/plugins/placeholder";
-import { CqlQuery } from "../lib";
 
 export const typeaheadTestId = "cql-input-typeahead";
 export const errorTestId = "cql-input-error";
@@ -27,7 +27,6 @@ export const errorMsgTestId = "cql-input-error-message";
 
 export type CqlConfig = {
   syntaxHighlighting?: boolean;
-  debugEl?: HTMLElement;
   renderPopoverContent?: RenderPopoverContent;
   theme?: DeepPartial<CqlTheme>;
   lang?: Partial<ScannerSettings>;

--- a/lib/cql/src/cqlInput/popover/ErrorPopover.ts
+++ b/lib/cql/src/cqlInput/popover/ErrorPopover.ts
@@ -1,27 +1,20 @@
 import { EditorView } from "prosemirror-view";
-import { Popover } from "./Popover";
 import { CLASS_ERROR, CLASS_VISIBLE, CqlError } from "../editor/plugins/cql";
+import { Popover } from "./Popover";
 
 export class ErrorPopover extends Popover {
-  private debugContainer: HTMLElement | undefined;
   private contentEl: HTMLElement;
   private visibilityTimeout: ReturnType<typeof setTimeout> | undefined;
 
   public constructor(
     protected view: EditorView,
     protected popoverEl: HTMLElement,
-    debugEl?: HTMLElement,
     private debounceTime = 500,
   ) {
     super(popoverEl);
 
     this.contentEl = document.createElement("div");
     popoverEl.appendChild(this.contentEl);
-
-    if (debugEl) {
-      this.debugContainer = document.createElement("div");
-      debugEl.appendChild(this.debugContainer);
-    }
 
     this.hide();
   }
@@ -32,18 +25,7 @@ export class ErrorPopover extends Popover {
       return;
     }
 
-    this.updateDebugContainer(error);
     this.debouncedShowErrorMessages(error);
-  };
-
-  private updateDebugContainer = (error: CqlError) => {
-    if (this.debugContainer) {
-      this.debugContainer.innerHTML = `
-        <h2>Error</h2>
-        <div>Position: ${error.position ?? "No position given"}</div>
-        <div>Message: ${error.message}</div>
-      `;
-    }
   };
 
   public hideErrorMessages = () => {

--- a/lib/cql/src/page.ts
+++ b/lib/cql/src/page.ts
@@ -107,42 +107,28 @@ const cqlEl = document.getElementById("cql")!;
 const queryEl = document.getElementById("query")!;
 const errorEl = document.getElementById("error")!;
 
-function handleQueryChange(e: CustomEvent<QueryChangeEventDetail>) {
-  const queryStr = e.detail.queryStr ?? "";
+function handleQueryChange(queryStr: string, errorMessage?: string) {
   setUrlParam("query", queryStr);
   queryEl.innerHTML = queryStr;
   cqlEl.innerHTML = queryStr.replaceAll(" ", "·");
-  errorEl.innerHTML = e.detail.error ?? "";
+  errorEl.innerHTML = errorMessage ?? "";
   updateDebugPanel(queryStr);
+}
+
+function handleQueryChangeEvent(e: CustomEvent<QueryChangeEventDetail>) {
+  handleQueryChange(e.detail.queryStr ?? "", e.detail.error);
 }
 
 dataSourceSelect.addEventListener("change", (e: Event) => {
   const source = (e.target as HTMLSelectElement).value;
   const inputHtmlTagValue = dataSourceMap[source];
   cqlInputContainer.innerHTML = `<${inputHtmlTagValue} autofocus id="${source}"></${inputHtmlTagValue}>`;
-  const cqlInput = cqlInputContainer.firstChild as HTMLElement;
-  cqlInput?.focus();
-  cqlInput?.addEventListener("queryChange", ((
-    e: CustomEvent<QueryChangeEventDetail>,
-  ) => {
-    const queryStr = e.detail.queryStr ?? "";
-    setUrlParam("query", queryStr);
-    queryEl.innerHTML = queryStr;
-    cqlEl.innerHTML = queryStr.replaceAll(" ", "·");
-    errorEl.innerHTML = e.detail.error ?? "";
-    updateDebugPanel(queryStr);
-  }) as EventListener);
+  const newCqlInput = cqlInputContainer.firstChild as HTMLElement;
+  newCqlInput?.focus();
+  handleQueryChange("");
+  newCqlInput?.addEventListener("queryChange", handleQueryChangeEvent);
 });
-cqlInput?.addEventListener("queryChange", ((
-  e: CustomEvent<QueryChangeEventDetail>,
-) => {
-  const queryStr = e.detail.queryStr ?? "";
-  setUrlParam("query", queryStr);
-  queryEl.innerHTML = queryStr;
-  cqlEl.innerHTML = queryStr.replaceAll(" ", "·");
-  errorEl.innerHTML = e.detail.error ?? "";
-  updateDebugPanel(queryStr);
-}) as EventListener);
+cqlInput?.addEventListener("queryChange", handleQueryChangeEvent);
 
 const params = new URLSearchParams(window.location.search);
 const endpoint = params.get("endpoint");


### PR DESCRIPTION
Refactor the rendering of debug information so that it is all handled based on events emitted from the CqlInput component, rather than being part of the component code itself.

Cleaner separation of concerns and a smaller public API for the component.

One trade-off is that we had to remove the suggestions debug output for the time being, because suggestion info is not emitted, and would have to be fetched separately. Something to think about for future work though: is there a good public API that we could provide which would facilitate this?

Should address https://github.com/guardian/cql/issues/77

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
