### PR TITLE
Add escaping for query strings, chip keys, and chip values

### DIFF
--- a/.changeset/olive-owls-lead.md
+++ b/.changeset/olive-owls-lead.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": minor
+---
+
+Add escaping for query strings, chip keys, and chip values

--- a/docs/notes.md
+++ b/docs/notes.md
@@ -196,3 +196,28 @@ How do we represent positive and negative search terms in the lexical grammar?
 3. ⚖️ Just take the first character of the lexeme, which is guaranteed to be `+|-` — trivial to implement, but it feels icky not to have a token representation; what if the symbols change? Every piece of code that makes this assumption will have to change too, without a clear interface to test whether we've caught every case
 
 Probably 2.
+
+## Escaping
+
+Escaping outside of quotes should function as expected, e.g.
+
+```
+"\"" -> `str<">`
+a\"b -> `str<a"b>`
+a\+b -> `str<a+b>`
+```
+
+What must be escaped in an unquoted string? Reserved chars, so `[-+:"]`. If in quotes, only quotes themselves need to be escaped. Should we require escaping anyhow, or change the rules? It's quite convenient to be able to quote escaped chars such that you don't have to read them.
+
+```
+"a+b" -> `str<a+b>`
+```
+
+Same rules can then apply to chip key/value:
+
+```
+"a\"b":c -> `chipKey<a"b>, chipValue<c>`
+"a+b":"d:e" -> `chipKey<a+b>, chipValue<c>`
+```
+
+Interpreter can normalise by quoting values with escapable chars.

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -744,6 +744,26 @@ describe("cql plugin", () => {
       expect(secondChip.attrs[IS_SELECTED]).toBe(true);
     });
 
+    it("should escape chip keys", async () => {
+      const { editor, waitFor } = createCqlEditor();
+
+      editor
+        .insertText("+")
+        .insertText(`"key+"`)
+
+      await waitFor(`"\\"key+\\"":`);
+    });
+
+    it("should escape chip values", async () => {
+         const queryStr = " +key:v";
+        const { editor, moveCaretToQueryPos, waitFor } =
+          createCqlEditor(queryStr);
+
+        await moveCaretToQueryPos(queryStr.indexOf("v"), 1);
+        await editor.insertText(`alue+:"`)
+        await waitFor(`key:"value+:\\""`)
+    });
+
     it.todo(
       "should not remove chip keys when hitting backspace from a chip value",
       async () => {

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -53,7 +53,6 @@ import {
 } from "../utils";
 import { chipKeyNodeView, chipNodeView, chipValueNodeView } from "../nodeView";
 import { DebugChangeEventDetail } from "../../../types/dom";
-import { logNode } from "../debug";
 
 const cqlPluginKey = new PluginKey<PluginState>("cql-plugin");
 
@@ -149,9 +148,7 @@ export const createCqlPlugin = ({
         }),
       );
     }
-    logNode(originalDoc);
-    console.log({queryBeforeParse, queryAfterParse: docToCqlStr(tr.doc) });
-logNode(tr.doc);
+
     tr.setMeta(ACTION_NEW_STATE, {
       tokens,
       error,

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -53,6 +53,7 @@ import {
 } from "../utils";
 import { chipKeyNodeView, chipNodeView, chipValueNodeView } from "../nodeView";
 import { DebugChangeEventDetail } from "../../../types/dom";
+import { logNode } from "../debug";
 
 const cqlPluginKey = new PluginKey<PluginState>("cql-plugin");
 
@@ -148,7 +149,9 @@ export const createCqlPlugin = ({
         }),
       );
     }
-
+    logNode(originalDoc);
+    console.log({queryBeforeParse, queryAfterParse: docToCqlStr(tr.doc) });
+logNode(tr.doc);
     tr.setMeta(ACTION_NEW_STATE, {
       tokens,
       error,

--- a/lib/cql/src/cqlInput/editor/utils.spec.ts
+++ b/lib/cql/src/cqlInput/editor/utils.spec.ts
@@ -137,6 +137,21 @@ describe("utils", () => {
       expect(node.toJSON()).toEqual(expected.toJSON());
     });
 
+    it.only("should unescape quotes within keys and values", async () => {
+      const tokens = await queryToProseMirrorTokens(
+        `+"key\\"":"value\\""`,
+      );
+      const node = tokensToDoc(tokens);
+
+      const expected = doc(
+        queryStr(""),
+        chip(chipKey(`key"`), chipValue(`value"`)),
+        queryStr(""),
+      );
+
+      expect(node.toJSON()).toEqual(expected.toJSON());
+    });
+
     it("should create chipWrappers for partial tags that precede existing tags", async () => {
       const tokens = await queryToProseMirrorTokens("+ +tag");
       const node = tokensToDoc(tokens);
@@ -316,6 +331,18 @@ describe("utils", () => {
       );
 
       const query = 'example +tag:"Tag with whitespace" ';
+
+      expect(docToCqlStr(queryDoc)).toBe(query);
+    });
+
+    it("should add quotes for chip keys and values that contain whitespace", () => {
+      const queryDoc = doc(
+        queryStr("example"),
+        chip(chipKey(`tag"key`), chipValue(`tag"value`)),
+        queryStr(),
+      );
+
+      const query = 'example +"tag\\"key":"tag\\"value" ';
 
       expect(docToCqlStr(queryDoc)).toBe(query);
     });

--- a/lib/cql/src/cqlInput/editor/utils.spec.ts
+++ b/lib/cql/src/cqlInput/editor/utils.spec.ts
@@ -137,7 +137,7 @@ describe("utils", () => {
       expect(node.toJSON()).toEqual(expected.toJSON());
     });
 
-    it.only("should unescape quotes within keys and values", async () => {
+    it("should unescape quotes within keys and values", async () => {
       const tokens = await queryToProseMirrorTokens(
         `+"key\\"":"value\\""`,
       );

--- a/lib/cql/src/lang/interpreter.spec.ts
+++ b/lib/cql/src/lang/interpreter.spec.ts
@@ -28,7 +28,7 @@ describe("interpreter", () => {
   });
 
   it("should escape reserved characters in chip keys and values", () => {
-    const queryStr = `key:\\"value\\"`;
+    const queryStr = `key:"\\"value\\""`;
     const query = parser(queryStr).queryAst!;
 
     const str = cqlQueryStrFromQueryAst(query);

--- a/lib/cql/src/lang/interpreter.spec.ts
+++ b/lib/cql/src/lang/interpreter.spec.ts
@@ -18,7 +18,7 @@ describe("interpreter", () => {
     expect(firstStr).toBe(secondStr);
   });
 
-  it.only("should escape reserved characters in quoted strings", () => {
+  it("should escape reserved characters in quoted strings", () => {
     const queryStr = `"\\"saus\\" \\"age\\""`;
     const query = parser(queryStr).queryAst!;
 
@@ -28,7 +28,7 @@ describe("interpreter", () => {
   });
 
   it("should escape reserved characters in chip keys and values", () => {
-    const queryStr = `"\\"\\(key \\:\\)\\"":"\\"\\(value \\)\\""`;
+    const queryStr = `key:\\"value\\"`;
     const query = parser(queryStr).queryAst!;
 
     const str = cqlQueryStrFromQueryAst(query);

--- a/lib/cql/src/lang/interpreter.spec.ts
+++ b/lib/cql/src/lang/interpreter.spec.ts
@@ -8,11 +8,31 @@ describe("interpreter", () => {
     const firstQuery = parser(
       `  +: "marina" +section:commentisfree "Byline Title":"John Doe"`,
     ).queryAst!;
-    const secondQuery = parser(`+: marina +section:"commentisfree" +"Byline Title":"John Doe"`).queryAst!;
+    const secondQuery = parser(
+      `+: marina +section:"commentisfree" +"Byline Title":"John Doe"`,
+    ).queryAst!;
 
     const firstStr = cqlQueryStrFromQueryAst(firstQuery);
     const secondStr = cqlQueryStrFromQueryAst(secondQuery);
 
     expect(firstStr).toBe(secondStr);
+  });
+
+  it.only("should escape reserved characters in quoted strings", () => {
+    const queryStr = `"\\"saus\\" \\"age\\""`;
+    const query = parser(queryStr).queryAst!;
+
+    const str = cqlQueryStrFromQueryAst(query);
+
+    expect(str).toBe(queryStr);
+  });
+
+  it("should escape reserved characters in chip keys and values", () => {
+    const queryStr = `"\\"\\(key \\:\\)\\"":"\\"\\(value \\)\\""`;
+    const query = parser(queryStr).queryAst!;
+
+    const str = cqlQueryStrFromQueryAst(query);
+
+    expect(str).toBe(queryStr);
   });
 });

--- a/lib/cql/src/lang/interpreter.ts
+++ b/lib/cql/src/lang/interpreter.ts
@@ -1,8 +1,9 @@
 import { CqlBinary, CqlExpr, CqlField, CqlQuery } from "./ast";
-import { hasWhitespace } from "./utils";
+import { escapeStr, hasWhitespace } from "./utils";
 
 export const cqlQueryStrFromQueryAst = (query: CqlQuery): string => {
   const { content } = query;
+
   if (!content) {
     return "";
   }
@@ -14,7 +15,9 @@ const strFromContent = (queryContent: CqlExpr): string | undefined => {
   const { content } = queryContent;
   switch (content.type) {
     case "CqlStr":
-      return content.searchExpr;
+      return hasWhitespace(content.searchExpr)
+        ? `"${escapeStr(content.searchExpr)}"`
+        : content.searchExpr;
     case "CqlGroup":
       return `(${strFromBinary(content.content).trim()})`;
     case "CqlBinary":
@@ -38,11 +41,11 @@ const strFromField = (field: CqlField): string => {
   const polarity = field.key.tokenType === "CHIP_KEY_POSITIVE" ? "" : "-";
   const keyLiteral = field.key.literal ?? "";
   const normalisedKey = hasWhitespace(keyLiteral)
-    ? `"${keyLiteral}"`
+    ? `"${escapeStr(keyLiteral)}"`
     : keyLiteral;
   const valueLiteral = field.value?.literal ?? "";
   const normalisedValue = hasWhitespace(valueLiteral)
-    ? `"${valueLiteral}"`
+    ? `"${escapeStr(valueLiteral)}"`
     : valueLiteral;
 
   return `${polarity}${normalisedKey ?? ""}:${normalisedValue}`;

--- a/lib/cql/src/lang/interpreter.ts
+++ b/lib/cql/src/lang/interpreter.ts
@@ -1,5 +1,5 @@
 import { CqlBinary, CqlExpr, CqlField, CqlQuery } from "./ast";
-import { escapeQuotes, hasWhitespace, shouldQuoteFieldValue } from "./utils";
+import { hasWhitespace, shouldQuoteFieldValue } from "./utils";
 
 export const cqlQueryStrFromQueryAst = (query: CqlQuery): string => {
   const { content } = query;

--- a/lib/cql/src/lang/interpreter.ts
+++ b/lib/cql/src/lang/interpreter.ts
@@ -1,5 +1,5 @@
 import { CqlBinary, CqlExpr, CqlField, CqlQuery } from "./ast";
-import { escapeStr, hasWhitespace } from "./utils";
+import { escapeQuotes, hasWhitespace, shouldQuoteFieldValue } from "./utils";
 
 export const cqlQueryStrFromQueryAst = (query: CqlQuery): string => {
   const { content } = query;
@@ -16,7 +16,7 @@ const strFromContent = (queryContent: CqlExpr): string | undefined => {
   switch (content.type) {
     case "CqlStr":
       return hasWhitespace(content.searchExpr)
-        ? `"${escapeStr(content.searchExpr)}"`
+        ? `"${content.searchExpr}"`
         : content.searchExpr;
     case "CqlGroup":
       return `(${strFromBinary(content.content).trim()})`;
@@ -40,13 +40,14 @@ const strFromBinary = (queryBinary: CqlBinary): string => {
 const strFromField = (field: CqlField): string => {
   const polarity = field.key.tokenType === "CHIP_KEY_POSITIVE" ? "" : "-";
   const keyLiteral = field.key.literal ?? "";
-  const normalisedKey = hasWhitespace(keyLiteral)
-    ? `"${escapeStr(keyLiteral)}"`
+  const normalisedKey = shouldQuoteFieldValue(keyLiteral)
+    ? `"${keyLiteral}"`
     : keyLiteral;
   const valueLiteral = field.value?.literal ?? "";
-  const normalisedValue = hasWhitespace(valueLiteral)
-    ? `"${escapeStr(valueLiteral)}"`
+  const normalisedValue = shouldQuoteFieldValue(valueLiteral)
+    ? `"${valueLiteral}"`
     : valueLiteral;
+  console.log({ keyLiteral, normalisedKey, valueLiteral, normalisedValue });
 
   return `${polarity}${normalisedKey ?? ""}:${normalisedValue}`;
 };

--- a/lib/cql/src/lang/interpreter.ts
+++ b/lib/cql/src/lang/interpreter.ts
@@ -47,7 +47,6 @@ const strFromField = (field: CqlField): string => {
   const normalisedValue = shouldQuoteFieldValue(valueLiteral)
     ? `"${valueLiteral}"`
     : valueLiteral;
-  console.log({ keyLiteral, normalisedKey, valueLiteral, normalisedValue });
 
   return `${polarity}${normalisedKey ?? ""}:${normalisedValue}`;
 };

--- a/lib/cql/src/lang/scanner.spec.ts
+++ b/lib/cql/src/lang/scanner.spec.ts
@@ -47,7 +47,7 @@ describe("scanner", () => {
     });
 
     it("should correctly handle escaped characters", () => {
-      assertTokens(`"\\"sausages\\""`, [quotedStringToken(`\\"sausages\\"`, 0, `"sausages"`), eofToken(14)]);
+      assertTokens(`\\"sausages\\"`, [unquotedStringToken(`\\"sausages\\"`, 0, `\\"sausages\\"`), eofToken(12)]);
     });
 
     it("should give a single token for strings separated with a space", () => {
@@ -263,6 +263,14 @@ describe("scanner", () => {
         new Token(TokenType.CHIP_KEY_POSITIVE, "tag", "tag", 0, 2),
         new Token(TokenType.CHIP_VALUE, ':"tone news:"', "tone news:", 3, 15),
         eofToken(16),
+      ]);
+    });
+
+    it("should tokenise key value pairs for fields when the key value is in quotes, containing an escaped quote", () => {
+      assertTokens('tag:"tone\\"news:"', [
+        new Token(TokenType.CHIP_KEY_POSITIVE, "tag", "tag", 0, 2),
+        new Token(TokenType.CHIP_VALUE, ':"tone\\"news:"', 'tone\\"news:', 3, 16),
+        eofToken(17),
       ]);
     });
 

--- a/lib/cql/src/lang/scanner.spec.ts
+++ b/lib/cql/src/lang/scanner.spec.ts
@@ -46,6 +46,10 @@ describe("scanner", () => {
       assertTokens('"sausages"', [quotedStringToken("sausages"), eofToken(10)]);
     });
 
+    it("should correctly handle escaped characters", () => {
+      assertTokens(`"\\"sausages\\""`, [quotedStringToken(`\\"sausages\\"`, 0, `"sausages"`), eofToken(14)]);
+    });
+
     it("should give a single token for strings separated with a space", () => {
       assertTokens('"magnificent octopus"', [
         quotedStringToken("magnificent octopus"),
@@ -63,6 +67,22 @@ describe("scanner", () => {
       ]);
     });
 
+    it("should handle escaped characters in keys", () => {
+      assertTokens("+tag\\::", [
+        new Token(TokenType.CHIP_KEY_POSITIVE, "+tag\\:", "tag:", 0, 5),
+        new Token(TokenType.CHIP_VALUE, ":", undefined, 6, 6),
+        eofToken(7),
+      ]);
+    });
+
+    it("should handle escaped characters in values", () => {
+      assertTokens("+tag\\::\\:", [
+        new Token(TokenType.CHIP_KEY_POSITIVE, "+tag\\:", "tag:", 0, 5),
+        new Token(TokenType.CHIP_VALUE, ":\\:", ":", 6, 8),
+        eofToken(9),
+      ]);
+    });
+
     it("should tokenise keys for fields with reversed polarity", () => {
       assertTokens("-tag:", [
         new Token(TokenType.CHIP_KEY_NEGATIVE, "-tag", "tag", 0, 3),
@@ -76,6 +96,16 @@ describe("scanner", () => {
         new Token(TokenType.CHIP_KEY_POSITIVE, "+tag", "tag", 0, 3),
         new Token(TokenType.CHIP_VALUE, ":tone/news", "tone/news", 4, 13),
         eofToken(14),
+      ]);
+    });
+
+    it("should tokenise consecutive fields", () => {
+      assertTokens("+tag:tone/news +tag:tone/news", [
+        new Token(TokenType.CHIP_KEY_POSITIVE, "+tag", "tag", 0, 3),
+        new Token(TokenType.CHIP_VALUE, ":tone/news", "tone/news", 4, 13),
+        new Token(TokenType.CHIP_KEY_POSITIVE, "+tag", "tag", 15, 18),
+        new Token(TokenType.CHIP_VALUE, ":tone/news", "tone/news", 19, 28),
+        eofToken(29),
       ]);
     });
 

--- a/lib/cql/src/lang/scanner.ts
+++ b/lib/cql/src/lang/scanner.ts
@@ -205,7 +205,7 @@ export class Scanner {
 
   private handleQuotedString = () => {
     const literal = this.consumeQuotedRange();
-    console.log({ literal });
+
     if (this.peek() === ":") {
       return this.addToken(TokenType.CHIP_KEY_POSITIVE, literal);
     }

--- a/lib/cql/src/lang/testUtils.ts
+++ b/lib/cql/src/lang/testUtils.ts
@@ -9,10 +9,10 @@ export const andToken = (start: number = 0) =>
   new Token(TokenType.AND, "AND", "AND", start, start + 3);
 export const eofToken = (start: number) =>
   new Token(TokenType.EOF, "", undefined, start, start);
-export const unquotedStringToken = (str: string, start: number = 0) =>
-  new Token(TokenType.STRING, str, str, start, start + str.length - 1);
-export const quotedStringToken = (str: string, start: number = 0) =>
-  new Token(TokenType.STRING, `"${str}"`, str, start, start + str.length + 1);
+export const unquotedStringToken = (str: string, start: number = 0, literal: string | undefined = undefined) =>
+  new Token(TokenType.STRING, str, literal ?? str, start, start + str.length - 1);
+export const quotedStringToken = (str: string, start: number = 0, literal: string | undefined = undefined) =>
+  new Token(TokenType.STRING, `"${str}"`, literal ?? str, start, start + str.length + 1);
 export const queryFieldKeyToken = (str: string, start: number = 0) =>
   new Token(TokenType.CHIP_KEY_POSITIVE, str, str, start, start + str.length);
 

--- a/lib/cql/src/lang/utils.spec.ts
+++ b/lib/cql/src/lang/utils.spec.ts
@@ -1,0 +1,8 @@
+import { describe, expect, test } from "bun:test";
+import { unescapeStr } from "./utils";
+
+describe("language utils", () => {
+    test("unescapeStr", () => {
+        expect(unescapeStr(`\\"sausages\\"`)).toBe(`"sausages"`)
+    })
+})

--- a/lib/cql/src/lang/utils.spec.ts
+++ b/lib/cql/src/lang/utils.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, test } from "bun:test";
-import { unescapeStr } from "./utils";
+import { unescapeQuotes } from "./utils";
 
 describe("language utils", () => {
     test("unescapeStr", () => {
-        expect(unescapeStr(`\\"sausages\\"`)).toBe(`"sausages"`)
+        expect(unescapeQuotes(`\\"sausages\\"`)).toBe(`"sausages"`)
     })
 })

--- a/lib/cql/src/lang/utils.spec.ts
+++ b/lib/cql/src/lang/utils.spec.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { unescapeQuotes } from "./utils";
 
 describe("language utils", () => {
-    test("unescapeStr", () => {
-        expect(unescapeQuotes(`\\"sausages\\"`)).toBe(`"sausages"`)
-    })
-})
+  test("unescapeStr", () => {
+    expect(unescapeQuotes(`\\"sausages\\"`)).toBe(`"sausages"`);
+  });
+});

--- a/lib/cql/src/lang/utils.ts
+++ b/lib/cql/src/lang/utils.ts
@@ -10,10 +10,10 @@ const escapedChar = /\\(?<escapedChar>[:()"])/g;
 export const unescapeQuotes = (str: string) =>
   str.replaceAll(escapedChar, "$1");
 
-export const escapeQuotes = (str: string) => str.replaceAll(`"`, '\\"');
+export const escapeQuotes = (str: string) => str.replaceAll(`"`, `\\"`);
 
 export const shouldQuoteFieldValue = (literal: string) =>
-  hasWhitespace(literal);
+  hasWhitespace(literal) || hasReservedChar(literal);
 
 export function* getPermutations<T>(
   permutation: T[],

--- a/lib/cql/src/lang/utils.ts
+++ b/lib/cql/src/lang/utils.ts
@@ -3,8 +3,13 @@ import { CqlBinary, CqlExpr, CqlField } from "./ast";
 const whitespaceR = /\s/;
 export const hasWhitespace = (str: string) => whitespaceR.test(str);
 
-const reservedChar = /[\s:()"]/;
+const reservedChar = /(?<escapedChar>[:()"])/g;
 export const hasReservedChar = (str: string) => reservedChar.test(str);
+
+const escapedChar = /\\(?<escapedChar>[:()"])/g
+export const unescapeStr = (str: string) => str.replaceAll(escapedChar, "$1")
+
+export const escapeStr = (str: string) => str.replaceAll(reservedChar, "\\$1")
 
 export function* getPermutations<T>(
   permutation: T[],

--- a/lib/cql/src/lang/utils.ts
+++ b/lib/cql/src/lang/utils.ts
@@ -1,15 +1,19 @@
 import { CqlBinary, CqlExpr, CqlField } from "./ast";
 
 const whitespaceR = /\s/;
-export const hasWhitespace = (str: string) => whitespaceR.test(str);
+export const hasWhitespace = (str: string) => !!str.match(whitespaceR);
 
 const reservedChar = /(?<escapedChar>[:()"])/g;
-export const hasReservedChar = (str: string) => reservedChar.test(str);
+export const hasReservedChar = (str: string) => !!str.match(reservedChar);
 
-const escapedChar = /\\(?<escapedChar>[:()"])/g
-export const unescapeStr = (str: string) => str.replaceAll(escapedChar, "$1")
+const escapedChar = /\\(?<escapedChar>[:()"])/g;
+export const unescapeQuotes = (str: string) =>
+  str.replaceAll(escapedChar, "$1");
 
-export const escapeStr = (str: string) => str.replaceAll(reservedChar, "\\$1")
+export const escapeQuotes = (str: string) => str.replaceAll(`"`, '\\"');
+
+export const shouldQuoteFieldValue = (literal: string) =>
+  hasWhitespace(literal);
 
 export function* getPermutations<T>(
   permutation: T[],
@@ -47,9 +51,7 @@ export const getCqlFieldsFromCqlBinary = (queryBinary: CqlBinary): CqlField[] =>
       : [],
   );
 
-const getCqlFieldsFromQueryExpr = (
-  queryContent: CqlExpr,
-): CqlField[] => {
+const getCqlFieldsFromQueryExpr = (queryContent: CqlExpr): CqlField[] => {
   switch (queryContent.content.type) {
     case "CqlField":
       return [queryContent.content];


### PR DESCRIPTION
## What does this change?

Adds escaping chars to the CQL language, and escaping rules to the input. 

Escape outside of quotes with `\`:

```
"\"" -> `str<">`
a\"b -> `str<a"b>`
a\+b -> `str<a+b>`
```

Escaping within chip keys and values happens automatically for everything but a trailing colon in chipKey position.

## How to test

- Automated tests in the scanner and integration tests for the editor should pass.
