### PR TITLE
Set up repo for trusted publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,6 @@ jobs:
         publish: bun changeset publish
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
   static-site:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -37,7 +37,6 @@ jobs:
     - name: Create Release Pull Request or Publish to npm
       id: changesets
       uses: changesets/action@v1
-      if: github.ref == 'refs/heads/main'
       with:
         title: "🦋 Release package updates"
         commit: "Bump package versions"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,6 +23,11 @@ jobs:
     - name: Setup bun
       uses: oven-sh/setup-bun@v1
 
+    - name: Setup npm
+      uses: actions/setup-node@v6
+      with:
+          node-version: 24
+
     - name: Build library
       working-directory: lib/cql
       run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,9 +39,10 @@ jobs:
       run: |
         bun install --frozen-lockfile
 
-    - name: Create Release Pull Request or Publish to npm
+    - name: Create PR for release, or publish to npm
       id: changesets
       uses: changesets/action@v1
+      if: github.ref == 'refs/heads/main'
       with:
         title: "🦋 Release package updates"
         commit: "Bump package versions"

--- a/lib/cql/package.json
+++ b/lib/cql/package.json
@@ -2,6 +2,10 @@
   "name": "@guardian/cql",
   "version": "1.8.3",
   "type": "module",
+  "repository": {
+    "type": "git",
+    "url": "github:guardian/cql"
+  },
   "scripts": {
     "dev": "vite",
     "build:page": "tsc && vite build",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
+  "engines": {
+    "npm": "11.7.0",
+    "node": "24.13.0"
+  },
   "dependencies": {
     "@changesets/cli": "^2.29.5"
   },


### PR DESCRIPTION
## What does this change?

Sets this repo up for trusted publishing —
- removes the NPM_TOKEN
- adds `id-token` to the workflow permissions for the job that contains the publish step
- bumps NPM to > 11.5.1

## How to test

Merge, and attempt to re-run the publish action that currently [fails on main.](https://github.com/guardian/cql/actions/runs/21491513397/job/61914969750) It should succeed.
