### PR TITLE
Ensure chip keys remain editable when the editor loses focus

### DIFF
--- a/.changeset/hot-shirts-walk.md
+++ b/.changeset/hot-shirts-walk.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Ensure that the chip separator is removed if the chip key is marked as editable again

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -243,6 +243,9 @@ export const createCqlInput = (
 
           chip-value {
             flex-shrink: 0;
+          }
+
+          chip-value[contenteditable="true"] {
             padding-right: 5px;
           }
 

--- a/lib/cql/src/cqlInput/editor/nodeView.ts
+++ b/lib/cql/src/cqlInput/editor/nodeView.ts
@@ -137,6 +137,9 @@ export const chipKeyNodeView: NodeViewConstructor = (node) => {
       } else {
         dom.classList.remove(CLASS_CHIP_KEY_READONLY);
         dom.setAttribute("contenteditable", "true");
+        if (separator.parentNode === dom) {
+          dom.removeChild(separator);
+        }
       }
 
       return true;

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -743,7 +743,17 @@ describe("cql plugin", () => {
 
         document.body.focus();
 
-         const chipKey = await findByText(container, "example");
+        const chipKey = await findByText(container, "example");
+
+        expect(chipKey.isContentEditable).toBe(true);
+      });
+
+      it("should not make chip keys read only when they have content, and the selection moves out of the chip key", async () => {
+        const queryStr = "+example: text";
+        const { container, editor } = createCqlEditor(queryStr);
+
+        editor.selectText("end");
+        const chipKey = await findByText(container, "example");
 
         expect(chipKey.isContentEditable).toBe(true);
       });

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -737,6 +737,17 @@ describe("cql plugin", () => {
         expect(editor.selection.from).toBe(chipKeyPos);
       });
 
+      it("should not make chip keys read only when they have content, but the editor is not focused", async () => {
+        const queryStr = "+example:";
+        const { container } = createCqlEditor(queryStr);
+
+        document.body.focus();
+
+         const chipKey = await findByText(container, "example");
+
+        expect(chipKey.isContentEditable).toBe(true);
+      });
+
       it("should make chip keys read only when the selection does not fall within their content and they are not empty", async () => {
         const queryStr = "a +tag:b c";
         const { container } = createCqlEditor(queryStr);

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -7,7 +7,7 @@ import {
   Transaction,
 } from "prosemirror-state";
 import { Mapping } from "prosemirror-transform";
-import { DecorationSet } from "prosemirror-view";
+import { DecorationSet, EditorView } from "prosemirror-view";
 import { CqlQuery } from "../../../lang/ast";
 import { createParser } from "../../../lang/Cql";
 import { Typeahead } from "../../../lang/typeahead";
@@ -124,6 +124,7 @@ export const createCqlPlugin = ({
 }) => {
   let typeaheadPopover: TypeaheadPopover | undefined;
   let errorPopover: ErrorPopover | undefined;
+  let editorView: EditorView | undefined;
 
   /**
    * Replaces the current document with the query it produces on parse.
@@ -277,7 +278,7 @@ export const createCqlPlugin = ({
         tr = newTr;
       }
 
-      applyChipLifecycleRules(tr);
+      applyChipLifecycleRules(tr, !!editorView?.hasFocus());
 
       return tr;
     },
@@ -452,6 +453,7 @@ export const createCqlPlugin = ({
       },
     },
     view(view) {
+      editorView = view;
       typeaheadPopover = new TypeaheadPopover(
         view,
         typeaheadEl,

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -7,7 +7,7 @@ import {
   Transaction,
 } from "prosemirror-state";
 import { Mapping } from "prosemirror-transform";
-import { DecorationSet, EditorView } from "prosemirror-view";
+import { DecorationSet } from "prosemirror-view";
 import { CqlQuery } from "../../../lang/ast";
 import { createParser } from "../../../lang/Cql";
 import { Typeahead } from "../../../lang/typeahead";
@@ -124,7 +124,6 @@ export const createCqlPlugin = ({
 }) => {
   let typeaheadPopover: TypeaheadPopover | undefined;
   let errorPopover: ErrorPopover | undefined;
-  let editorView: EditorView | undefined;
 
   /**
    * Replaces the current document with the query it produces on parse.
@@ -278,7 +277,7 @@ export const createCqlPlugin = ({
         tr = newTr;
       }
 
-      applyChipLifecycleRules(tr, !!editorView?.hasFocus());
+      applyChipLifecycleRules(tr);
 
       return tr;
     },
@@ -453,7 +452,6 @@ export const createCqlPlugin = ({
       },
     },
     view(view) {
-      editorView = view;
       typeaheadPopover = new TypeaheadPopover(
         view,
         typeaheadEl,

--- a/lib/cql/src/cqlInput/editor/utils.ts
+++ b/lib/cql/src/cqlInput/editor/utils.ts
@@ -701,7 +701,7 @@ export const getNodeTypeAtSelection = (view: EditorView) => {
  * - chip values are readonly until their sibling chip key has a value
  * - chips that do not contain any values, nor a selection, are removed
  */
-export const applyChipLifecycleRules = (tr: Transaction, hasFocus: boolean): void => {
+export const applyChipLifecycleRules = (tr: Transaction): void => {
   const { from, to } = tr.selection;
   tr.doc.descendants((node, pos) => {
     switch (node.type) {
@@ -712,21 +712,22 @@ export const applyChipLifecycleRules = (tr: Transaction, hasFocus: boolean): voi
           return;
         }
 
-        const keyNodeStart = pos + 1;
-        const keyNodeEnd = keyNodeStart + keyNode.nodeSize;
-        const selectionCoversChipKey = from >= keyNodeStart && to <= keyNodeEnd;
-        const chipKeyHasContent = !!keyNode.textContent;
-
         const { node: valueNode, offset } = node.childBefore(node.nodeSize - 2);
 
         if (!valueNode) {
           return;
         }
 
+        const keyNodeStart = pos + 1;
+
         const valueNodeStart = pos + offset + 1;
+        const valueNodeEnd = valueNodeStart + valueNode.nodeSize;
         const valueNodeContent = !!valueNode.textContent;
 
-        if ((hasFocus && !selectionCoversChipKey && chipKeyHasContent) || valueNodeContent) {
+        const selectionCoversChipValue =
+          from >= valueNodeStart && to <= valueNodeEnd;
+
+        if (selectionCoversChipValue || valueNodeContent) {
           tr.setNodeAttribute(
             keyNodeStart,
             IS_READ_ONLY,

--- a/lib/cql/src/cqlInput/editor/utils.ts
+++ b/lib/cql/src/cqlInput/editor/utils.ts
@@ -701,7 +701,7 @@ export const getNodeTypeAtSelection = (view: EditorView) => {
  * - chip values are readonly until their sibling chip key has a value
  * - chips that do not contain any values, nor a selection, are removed
  */
-export const applyChipLifecycleRules = (tr: Transaction): void => {
+export const applyChipLifecycleRules = (tr: Transaction, hasFocus: boolean): void => {
   const { from, to } = tr.selection;
   tr.doc.descendants((node, pos) => {
     switch (node.type) {
@@ -724,8 +724,9 @@ export const applyChipLifecycleRules = (tr: Transaction): void => {
         }
 
         const valueNodeStart = pos + offset + 1;
+        const valueNodeContent = !!valueNode.textContent;
 
-        if (!selectionCoversChipKey && chipKeyHasContent) {
+        if ((hasFocus && !selectionCoversChipKey && chipKeyHasContent) || valueNodeContent) {
           tr.setNodeAttribute(
             keyNodeStart,
             IS_READ_ONLY,


### PR DESCRIPTION
## What does this change?

At the moment, we make chip keys readonly when the selection moves out of them. This means that if you're typing a chip key, and you navigate away from them within the editor, or the input loses focus, the chip key will be readonly when you return.

This PR ensures chip keys remain editable in those scenarios: the chip key will only become readonly when the caret enters its sibling chip value, which can only happen when the user either 
- selects a value from the dropdown
- enters `:` after the chipkey

This hopefully only applies the readonly behaviour at the correct moment.

## How has this change been tested?

- Unit test added
- Tested manually

Fixes https://github.com/guardian/cql/issues/105, #107 (drive-by via [f2e4e89](https://github.com/guardian/cql/pull/113/commits/f2e4e89d7ce30ac37c506a0e3fd9989084e29a49))