### PR TITLE
Do not remove succeeding text on click delete

### DIFF
--- a/.changeset/tough-toes-camp.md
+++ b/.changeset/tough-toes-camp.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Remove magic number causing succeeding text to be removedwhen chips are deleted with a click

--- a/lib/cql/src/cqlInput/editor/nodeView.ts
+++ b/lib/cql/src/cqlInput/editor/nodeView.ts
@@ -45,7 +45,7 @@ export const chipNodeView: NodeViewConstructor = (
 
     const { node, pos } = result;
 
-    removeChipCoveringRange(pos, pos + node.nodeSize + 1)(view.state, view.dispatch);
+    removeChipCoveringRange(pos, pos + node.nodeSize)(view.state, view.dispatch);
   };
 
   const handlePolarityClickEvent = () => {

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -1073,12 +1073,12 @@ describe("cql plugin", () => {
     });
 
     it("removes the chip via click", async () => {
-      const { editor, waitFor } = createCqlEditor("+tag:a");
+      const { editor, waitFor } = createCqlEditor("before +tag:a after");
 
       const deleteBtn = await findByText(editor.view.dom, "×");
       await fireEvent.click(deleteBtn);
 
-      await waitFor("");
+      await waitFor("before after");
     });
 
     it("removes a chip via Cmd+Backspace", async () => {


### PR DESCRIPTION
## What does this change?

Do not remove succeeding text when clicking the delete button on a chip.

## How has this change been tested?

- I've added some preceding and succeeding text to the click delete test. The test fails after that change. The commit after fixes the test. (Cannot quite recall why the magic +1 was there!)
- I've also tested manually.

Fixes https://github.com/guardian/cql/issues/114.

