### PR TITLE
Move cql-sandbox from gutools to guexperiments

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,7 +81,7 @@ jobs:
         uses: guardian/actions-static-site@v3
         with:
           app: cql-sandbox
-          domain: cql-sandbox.gutools.co.uk
+          domain: cql-sandbox.guexperiments.co.uk
           roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           githubToken: ${{ secrets.GITHUB_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ An experiment to see if a query DSL, coupled with first-class typeahead and synt
 
 ![intro](https://github.com/guardian/cql/assets/7767575/22d3dba7-ace6-4c3a-8dcf-9755728fa98b)
 
-Play in the sandbox at https://cql-sandbox.gutools.co.uk/.
+Play in the sandbox at https://cql-sandbox.guexperiments.co.uk/.
 
 ## Why?
 


### PR DESCRIPTION
## What does this change?

Moves cql-sandbox from cql-sandbox.gutools.co.uk to cql-sandbox.guexperiments.co.uk.

We now have the domain name guexperiments.co.uk which is a more natural home for the CQL Sandbox.