### PR TITLE
Allow +/- to initiate chips on mobile

### DIFF
--- a/.changeset/famous-bars-brake.md
+++ b/.changeset/famous-bars-brake.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Allow +/- to initiate chips on mobile

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -471,19 +471,22 @@ describe("cql plugin", () => {
         });
       });
 
+      const typeViaHandleTextInput = (view: EditorView, text: string) => {
+        view.someProp("handleTextInput", (f) =>
+          f(view, view.state.selection.from, view.state.selection.to, text),
+        );
+      };
+
       describe("via text input (mobile)", () => {
         // These tests call handleTextInput directly (via view.someProp) to
         // simulate the path used by mobile soft keyboards, which do not
         // reliably fire keydown events — unlike the desktop path through
         // handleKeyDown.
-
         it("creates a chip when '+' is received as text input", async () => {
           const { editor, waitFor } = createCqlEditor();
           const { view } = editor;
 
-          view.someProp("handleTextInput", (f) =>
-            f(view, view.state.selection.from, view.state.selection.to, "+"),
-          );
+          typeViaHandleTextInput(view, "+");
 
           await waitFor(":");
         });
@@ -492,46 +495,9 @@ describe("cql plugin", () => {
           const { editor, waitFor } = createCqlEditor();
           const { view } = editor;
 
-          view.someProp("handleTextInput", (f) =>
-            f(view, view.state.selection.from, view.state.selection.to, "-"),
-          );
+          typeViaHandleTextInput(view, "-");
 
           await waitFor("-:");
-        });
-
-        it("does not create a chip when '+' immediately follows a non-whitespace character", async () => {
-          const { editor, waitFor } = createCqlEditor("c");
-          const { view } = editor;
-          const from = view.state.selection.from;
-
-          // Simulate mobile text input: call handleTextInput; if unhandled,
-          // insert the character as plain text (what the browser does).
-          const handled = view.someProp("handleTextInput", (f) =>
-            f(view, from, from, "+"),
-          );
-          if (!handled) {
-            view.dispatch(view.state.tr.insertText("+", from, from));
-          }
-
-          await waitFor("c+");
-        });
-
-        it("does not create a chip when '-' immediately precedes a non-whitespace character", async () => {
-          const { editor, waitFor } = createCqlEditor("a");
-          const { view } = editor;
-
-          // Position caret before 'a'
-          editor.selectText(1);
-          const from = view.state.selection.from;
-
-          const handled = view.someProp("handleTextInput", (f) =>
-            f(view, from, from, "-"),
-          );
-          if (!handled) {
-            view.dispatch(view.state.tr.insertText("-", from, from));
-          }
-
-          await waitFor("-a");
         });
       });
 

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -471,6 +471,70 @@ describe("cql plugin", () => {
         });
       });
 
+      describe("via text input (mobile)", () => {
+        // These tests call handleTextInput directly (via view.someProp) to
+        // simulate the path used by mobile soft keyboards, which do not
+        // reliably fire keydown events — unlike the desktop path through
+        // handleKeyDown.
+
+        it("creates a chip when '+' is received as text input", async () => {
+          const { editor, waitFor } = createCqlEditor();
+          const { view } = editor;
+
+          view.someProp("handleTextInput", (f) =>
+            f(view, view.state.selection.from, view.state.selection.to, "+"),
+          );
+
+          await waitFor(":");
+        });
+
+        it("creates a negative chip when '-' is received as text input", async () => {
+          const { editor, waitFor } = createCqlEditor();
+          const { view } = editor;
+
+          view.someProp("handleTextInput", (f) =>
+            f(view, view.state.selection.from, view.state.selection.to, "-"),
+          );
+
+          await waitFor("-:");
+        });
+
+        it("does not create a chip when '+' immediately follows a non-whitespace character", async () => {
+          const { editor, waitFor } = createCqlEditor("c");
+          const { view } = editor;
+          const from = view.state.selection.from;
+
+          // Simulate mobile text input: call handleTextInput; if unhandled,
+          // insert the character as plain text (what the browser does).
+          const handled = view.someProp("handleTextInput", (f) =>
+            f(view, from, from, "+"),
+          );
+          if (!handled) {
+            view.dispatch(view.state.tr.insertText("+", from, from));
+          }
+
+          await waitFor("c+");
+        });
+
+        it("does not create a chip when '-' immediately precedes a non-whitespace character", async () => {
+          const { editor, waitFor } = createCqlEditor("a");
+          const { view } = editor;
+
+          // Position caret before 'a'
+          editor.selectText(1);
+          const from = view.state.selection.from;
+
+          const handled = view.someProp("handleTextInput", (f) =>
+            f(view, from, from, "-"),
+          );
+          if (!handled) {
+            view.dispatch(view.state.tr.insertText("-", from, from));
+          }
+
+          await waitFor("-a");
+        });
+      });
+
       describe("text suggestions", () => {
         it("displays a popover at the start of a value field", async () => {
           const queryStr = "example +tag:";

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -379,6 +379,12 @@ export const createCqlPlugin = ({
           }
         }
       },
+      handleTextInput(view, _from, _to, text) {
+        if (text === "+" || text === "-") {
+          return maybeAddChipAtPolarityChar(text)(view);
+        }
+        return false;
+      },
       handleDOMEvents: {
         blur: (view) => {
           view.dispatch(

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -380,8 +380,10 @@ export const createCqlPlugin = ({
         }
       },
       handleTextInput(view, _from, _to, text) {
-        if (text === "+" || text === "-") {
-          return maybeAddChipAtPolarityChar(text)(view);
+        switch (text) {
+          case "+":
+          case "-":
+            return maybeAddChipAtPolarityChar(text)(view);
         }
         return false;
       },


### PR DESCRIPTION
Co-authored by Claude Opus 4.6, description written by a human, 48.

## What does this change?

Chips are impossible to add using mobile keyboard. This was verified to work. I checked if it negatively affects desktop, but couldn't find any issues. 🤖 was adamant it’s OK, but they often are.

🤖 says:

> ## Fix: chip trigger (`+`/`-`) on mobile virtual keyboards
> Mobile virtual keyboards (Android, iOS) often don't fire `keydown` events with correct `event.key` values for punctuation — they arrive as `key: "Unidentified"` or go through composition/input events instead. This means the existing `handleKeyDown` check for `+`/`-` never fires on mobile, making chip creation impossible on touch devices.
> ### Fix
> Add `handleTextInput` plugin prop — ProseMirror's input-method-agnostic hook that fires whenever text is inserted regardless of input mechanism. It calls the same `maybeAddChipAtPolarityChar` function, so all existing guards (no mid-word triggers, `-` adjacency check) still apply.
> ### Why it's safe for desktop
> On desktop, `handleKeyDown` catches `+`/`-` first and returns `true` → ProseMirror calls `preventDefault()` → the text is never inserted → `handleTextInput` never fires. The new code path is unreachable on desktop keyboards.

## How has this change been tested?

All 197 tests pass, 0 failures. Tested on Chrome for Android latest beta.

## How can we measure success?

If someone would want to use chips on mobile they will feel instant success.
