### PR TITLE
Allow clicks below CQL dropdown

### DIFF
--- a/.changeset/green-cars-look.md
+++ b/.changeset/green-cars-look.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Allow clicks below CQL dropdown

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -396,8 +396,6 @@ export const createCqlInput = (
           .Cql__TypeaheadPopoverContainer, .Cql__ErrorPopover {
             position: absolute;
             min-width: ${typeahead.layout.minWidth};
-            height: 100%;
-            max-height: min(80vh, 400px);
             margin: 0;
             padding: 0;
             background: none;
@@ -407,7 +405,8 @@ export const createCqlInput = (
           .Cql__TypeaheadPopover {
             display: flex;
             width: 100%;
-            max-height: 100%;
+            height: 100%;
+            max-height: min(80vh, 400px);
             padding: ${typeahead.layout.padding};
             font-size: ${baseFontSize};
             border-radius: ${typeahead.layout.borderRadius};

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -404,10 +404,6 @@ export const createCqlInput = (
             border: none;
           }
 
-          .Cql__TypeaheadPopoverContainer > * {
-            pointer-events: auto;
-          }
-
           .Cql__TypeaheadPopover {
             display: flex;
             width: 100%;

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -405,6 +405,10 @@ export const createCqlInput = (
             pointer-events: none;
           }
 
+          .Cql__TypeaheadPopoverContainer > * {
+            pointer-events: auto;
+          }
+
           .Cql__TypeaheadPopover {
             display: flex;
             pointer-events: auto;

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -402,7 +402,6 @@ export const createCqlInput = (
             padding: 0;
             background: none;
             border: none;
-            pointer-events: none;
           }
 
           .Cql__TypeaheadPopoverContainer > * {
@@ -411,7 +410,6 @@ export const createCqlInput = (
 
           .Cql__TypeaheadPopover {
             display: flex;
-            pointer-events: auto;
             width: 100%;
             max-height: 100%;
             padding: ${typeahead.layout.padding};

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -402,10 +402,12 @@ export const createCqlInput = (
             padding: 0;
             background: none;
             border: none;
+            pointer-events: none;
           }
 
           .Cql__TypeaheadPopover {
             display: flex;
+            pointer-events: auto;
             width: 100%;
             max-height: 100%;
             padding: ${typeahead.layout.padding};


### PR DESCRIPTION
Co-authored by Claude Opus 4.6, description written by a human, 48.

## What does this change?

Suggestions dropdown has invisible area below where no clicks work:

<img width="584" height="518" alt="hover2" src="https://github.com/user-attachments/assets/de95a3c4-1d54-429a-a23a-0096b9ffc16a" />

I played with this fix and tried to break it, but dismissing by click outside/ESC works, clicking tapping items works, I couldn't break it.

🤖 narrative:

> Fix typeahead popover intercepting clicks in empty space below suggestions.
> 
> The `.Cql__TypeaheadPopoverContainer` has `height: 100%` to support scroll on long lists, but this means it extends well beyond the visible dropdown content. Clicks/taps in this dead space are swallowed by the container instead of reaching elements underneath.
> 
> Fix: `pointer-events: none` on the container, `pointer-events: auto` on the inner `.Cql__TypeaheadPopover`. The visible dropdown remains fully interactive; the invisible overflow is click-through.

## How has this change been tested?

I tested a patched library in me toy. Also bun happy.

## How can we measure success?

No invisible forces at play. World is explainable again. If a tad boring.