### PR TITLE
Fix dropdown keyboard traversal when item on hover

### DIFF
--- a/.changeset/red-pets-work.md
+++ b/.changeset/red-pets-work.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Fix dropdown keyboard traversal when item on hover

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
@@ -19,8 +19,15 @@ describe("TextSuggestionContent", () => {
   });
 
   const setup = async (count = 5) => {
+    // The component is always rendered inside a shadow root in production
+    // (see CqlInput.ts). A document-level listener sees events dispatched
+    // from within an open shadow root differently to plain DOM (`target` is
+    // retargeted to the shadow host), so we replicate that topology here.
+    const host = document.createElement("div");
+    document.body.appendChild(host);
+    const shadowRoot = host.attachShadow({ mode: "open" });
     const container = document.createElement("div");
-    document.body.appendChild(container);
+    shadowRoot.appendChild(container);
 
     let actionHandler: ActionHandler | undefined;
     const subscribeToAction: ActionSubscriber = (handler) => {
@@ -70,7 +77,11 @@ describe("TextSuggestionContent", () => {
         overOptionIndex === undefined
           ? document
           : getOptions()[overOptionIndex];
-      target.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      // `composed: true` matches real UI events, which cross shadow
+      // boundaries so a document-level listener can observe them at all.
+      target.dispatchEvent(
+        new MouseEvent("mousemove", { bubbles: true, composed: true }),
+      );
       await tick();
     };
 

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
@@ -5,6 +5,7 @@ import { TextSuggestionOption } from "../../../lang/types";
 import type { TextSuggestion } from "../../../lang/types";
 import type { ActionHandler, ActionSubscriber } from "../TypeaheadPopover";
 import { tick } from "../../../utils/test";
+import { fireEvent } from "@testing-library/dom";
 
 describe("TextSuggestionContent", () => {
   const createSuggestion = (count: number): TextSuggestion => ({
@@ -26,7 +27,7 @@ describe("TextSuggestionContent", () => {
     document.body.innerHTML = "";
   });
 
-  const setup = async (count = 5) => {
+  const renderTextSuggestions = async (suggestionCount = 5) => {
     // The component is always rendered inside a shadow root in production
     // (see CqlInput.ts). A document-level listener sees events dispatched
     // from within an open shadow root differently to plain DOM (`target` is
@@ -51,12 +52,12 @@ describe("TextSuggestionContent", () => {
     };
 
     render(
-      h(TextSuggestionContent, {
-        suggestion: createSuggestion(count),
-        isPending: false,
-        onSelect: () => {},
-        subscribeToAction,
-      }),
+      <TextSuggestionContent
+        suggestion={createSuggestion(5)}
+        isPending={false}
+        onSelect={() => {}}
+        subscribeToAction={subscribeToAction}
+      />,
       container,
     );
 
@@ -82,7 +83,6 @@ describe("TextSuggestionContent", () => {
 
     const sendAction = async (action: "up" | "down") => {
       actionHandler?.(action);
-      await tick();
     };
 
     const moveMouse = async (overOptionIndex?: number) => {
@@ -90,19 +90,15 @@ describe("TextSuggestionContent", () => {
         overOptionIndex === undefined
           ? document
           : getOptions()[overOptionIndex];
-      // `composed: true` matches real UI events, which cross shadow
-      // boundaries so a document-level listener can observe them at all.
-      target.dispatchEvent(
-        new MouseEvent("mousemove", { bubbles: true, composed: true }),
-      );
-      await tick();
+
+      fireEvent.mouseMove(target);
     };
 
     return { getOptions, getSelectedIndex, hover, sendAction, moveMouse };
   };
 
   it("selects the hovered option when the mouse moves over it", async () => {
-    const { getSelectedIndex, hover } = await setup();
+    const { getSelectedIndex, hover } = await renderTextSuggestions();
 
     await hover(2);
 
@@ -110,7 +106,7 @@ describe("TextSuggestionContent", () => {
   });
 
   it("does not let a hover-only mouseenter (no mousemove) override keyboard navigation", async () => {
-    const { getSelectedIndex, hover, sendAction } = await setup();
+    const { getSelectedIndex, hover, sendAction } = await renderTextSuggestions();
 
     // The user is hovering over option 1 when they start pressing arrow keys.
     await hover(1);
@@ -130,7 +126,7 @@ describe("TextSuggestionContent", () => {
   });
 
   it("resumes tracking hover once the mouse genuinely moves again", async () => {
-    const { getSelectedIndex, hover, sendAction, moveMouse } = await setup();
+    const { getSelectedIndex, hover, sendAction, moveMouse } = await renderTextSuggestions();
 
     await hover(1);
     await sendAction("down");
@@ -143,7 +139,7 @@ describe("TextSuggestionContent", () => {
   });
 
   it("re-selects the still-hovered option on the first genuine movement, without needing to leave and re-enter it", async () => {
-    const { getSelectedIndex, hover, sendAction, moveMouse } = await setup();
+    const { getSelectedIndex, hover, sendAction, moveMouse } = await renderTextSuggestions();
 
     // The mouse is hovering over option 1 when the user starts navigating
     // with the keyboard, ending up on option 2.

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
@@ -65,8 +65,12 @@ describe("TextSuggestionContent", () => {
       await tick();
     };
 
-    const moveMouse = async () => {
-      document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+    const moveMouse = async (overOptionIndex?: number) => {
+      const target =
+        overOptionIndex === undefined
+          ? document
+          : getOptions()[overOptionIndex];
+      target.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
       await tick();
     };
 
@@ -112,5 +116,22 @@ describe("TextSuggestionContent", () => {
     await hover(3);
 
     expect(getSelectedIndex()).toBe(3);
+  });
+
+  it("re-selects the still-hovered option on the first genuine movement, without needing to leave and re-enter it", async () => {
+    const { getSelectedIndex, hover, sendAction, moveMouse } = await setup();
+
+    // The mouse is hovering over option 1 when the user starts navigating
+    // with the keyboard, ending up on option 2.
+    await hover(1);
+    await sendAction("down");
+    expect(getSelectedIndex()).toBe(2);
+
+    // The mouse then genuinely moves, but without leaving option 1 - so no
+    // new "mouseenter" fires there. Selection should still snap back to
+    // option 1, since that's where the pointer actually is.
+    await moveMouse(1);
+
+    expect(getSelectedIndex()).toBe(1);
   });
 });

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { h, render } from "preact";
+import { TextSuggestionContent } from "./TextSuggestionContent";
+import { TextSuggestionOption } from "../../../lang/types";
+import type { TextSuggestion } from "../../../lang/types";
+import type { ActionHandler, ActionSubscriber } from "../TypeaheadPopover";
+import { tick } from "../../../utils/test";
+
+describe("TextSuggestionContent", () => {
+  const createSuggestion = (count: number): TextSuggestion => ({
+    from: 0,
+    to: 0,
+    type: "TEXT",
+    position: "chipValue",
+    suggestions: Array.from(
+      { length: count },
+      (_, i) => new TextSuggestionOption(`Option ${i}`, `option-${i}`),
+    ),
+  });
+
+  const setup = async (count = 5) => {
+    const container = document.createElement("div");
+    document.body.appendChild(container);
+
+    let actionHandler: ActionHandler | undefined;
+    const subscribeToAction: ActionSubscriber = (handler) => {
+      actionHandler = handler;
+      return () => {
+        actionHandler = undefined;
+      };
+    };
+
+    render(
+      h(TextSuggestionContent, {
+        suggestion: createSuggestion(count),
+        isPending: false,
+        onSelect: () => {},
+        subscribeToAction,
+      }),
+      container,
+    );
+
+    // Let mount-time effects (subscribing to actions, resetting the current
+    // option for the initial suggestion) settle before interacting, just as
+    // they would have settled long before a human could move a mouse.
+    await tick();
+
+    const getOptions = () =>
+      Array.from(container.querySelectorAll<HTMLElement>(".Cql__Option"));
+
+    const getSelectedIndex = () =>
+      getOptions().findIndex((el) =>
+        el.classList.contains("Cql__Option--is-selected"),
+      );
+
+    const hover = async (index: number) => {
+      getOptions()[index].dispatchEvent(
+        new MouseEvent("mouseenter", { bubbles: true }),
+      );
+      await tick();
+    };
+
+    const sendAction = async (action: "up" | "down") => {
+      actionHandler?.(action);
+      await tick();
+    };
+
+    const moveMouse = async () => {
+      document.dispatchEvent(new MouseEvent("mousemove", { bubbles: true }));
+      await tick();
+    };
+
+    return { getOptions, getSelectedIndex, hover, sendAction, moveMouse };
+  };
+
+  it("selects the hovered option when the mouse moves over it", async () => {
+    const { getSelectedIndex, hover } = await setup();
+
+    await hover(2);
+
+    expect(getSelectedIndex()).toBe(2);
+  });
+
+  it("does not let a hover-only mouseenter (no mousemove) override keyboard navigation", async () => {
+    const { getSelectedIndex, hover, sendAction } = await setup();
+
+    // The user is hovering over option 1 when they start pressing arrow keys.
+    await hover(1);
+    expect(getSelectedIndex()).toBe(1);
+
+    await sendAction("down");
+    expect(getSelectedIndex()).toBe(2);
+
+    // Scrolling the list to keep the new selection in view moves the options
+    // underneath the still-stationary mouse cursor. The browser responds by
+    // firing a "mouseenter" on whichever option now sits under the pointer -
+    // simulated here by re-firing mouseenter on option 1 without any
+    // "mousemove" in between, exactly as happens in the browser.
+    await hover(1);
+
+    expect(getSelectedIndex()).toBe(2);
+  });
+
+  it("resumes tracking hover once the mouse genuinely moves again", async () => {
+    const { getSelectedIndex, hover, sendAction, moveMouse } = await setup();
+
+    await hover(1);
+    await sendAction("down");
+    expect(getSelectedIndex()).toBe(2);
+
+    await moveMouse();
+    await hover(3);
+
+    expect(getSelectedIndex()).toBe(3);
+  });
+});

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "bun:test";
+import { afterEach, describe, expect, it } from "bun:test";
 import { h, render } from "preact";
 import { TextSuggestionContent } from "./TextSuggestionContent";
 import { TextSuggestionOption } from "../../../lang/types";
@@ -18,6 +18,14 @@ describe("TextSuggestionContent", () => {
     ),
   });
 
+  let cleanup: (() => void) | undefined;
+
+  afterEach(() => {
+    cleanup?.();
+    cleanup = undefined;
+    document.body.innerHTML = "";
+  });
+
   const setup = async (count = 5) => {
     // The component is always rendered inside a shadow root in production
     // (see CqlInput.ts). A document-level listener sees events dispatched
@@ -28,6 +36,11 @@ describe("TextSuggestionContent", () => {
     const shadowRoot = host.attachShadow({ mode: "open" });
     const container = document.createElement("div");
     shadowRoot.appendChild(container);
+
+    cleanup = () => {
+      render(null, container);
+      host.remove();
+    };
 
     let actionHandler: ActionHandler | undefined;
     const subscribeToAction: ActionSubscriber = (handler) => {

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.spec.tsx
@@ -53,7 +53,7 @@ describe("TextSuggestionContent", () => {
 
     render(
       <TextSuggestionContent
-        suggestion={createSuggestion(5)}
+        suggestion={createSuggestion(suggestionCount)}
         isPending={false}
         onSelect={() => {}}
         subscribeToAction={subscribeToAction}

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -92,12 +92,15 @@ export const TextSuggestionContent = ({
       const hoveredOption = event
         .composedPath()
         .find(
-          (node): node is Element =>
-            node instanceof Element && node.hasAttribute("data-index"),
+          (node): node is HTMLElement =>
+            node instanceof HTMLElement &&
+            node.classList.contains("Cql__Option") &&
+            node.hasAttribute("data-index"),
         );
-      const hoveredIndex = hoveredOption?.getAttribute("data-index");
-      if (hoveredIndex !== null && hoveredIndex !== undefined) {
-        setCurrentOptionIndex(Number(hoveredIndex));
+      const hoveredIndexAttr = hoveredOption?.getAttribute("data-index");
+      const hoveredIndex = hoveredIndexAttr === null ? NaN : Number(hoveredIndexAttr);
+      if (Number.isFinite(hoveredIndex)) {
+        setCurrentOptionIndex(hoveredIndex);
       }
     };
     document.addEventListener("mousemove", handleMouseMove);

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -86,10 +86,15 @@ export const TextSuggestionContent = ({
       // will fire to select it. Select whatever option is under the pointer
       // on this first genuine movement, so the mouse doesn't have to leave
       // and re-enter the option to regain control.
-      const hoveredOption =
-        event.target instanceof Element
-          ? event.target.closest("[data-index]")
-          : null;
+      // The popover is rendered inside a shadow root, so `event.target` here
+      // would be retargeted to the shadow host - we need `composedPath()` to
+      // see the actual option element the pointer is over.
+      const hoveredOption = event
+        .composedPath()
+        .find(
+          (node): node is Element =>
+            node instanceof Element && node.hasAttribute("data-index"),
+        );
       const hoveredIndex = hoveredOption?.getAttribute("data-index");
       if (hoveredIndex !== null && hoveredIndex !== undefined) {
         setCurrentOptionIndex(Number(hoveredIndex));

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -26,11 +26,20 @@ export const TextSuggestionContent = ({
   const showDescription = suggestion.position === "chipKey";
   const currentItemRef = useRef<HTMLDivElement | null>(null);
   const [currentOptionIndex, setCurrentOptionIndex] = useState(0);
+  // Programmatically scrolling the list to keep the keyboard-selected item in
+  // view (see the effect below) moves the options underneath a stationary
+  // mouse cursor. Browsers respond to that by firing a "mouseenter" on
+  // whichever option ends up under the pointer, which would otherwise hijack
+  // keyboard navigation. We ignore hover-driven selection until the mouse
+  // physically moves again, so hovering only takes effect after a genuine
+  // mouse movement.
+  const ignoreHoverRef = useRef(false);
 
   useEffect(() => {
     const unsubscribe = subscribeToAction((action) => {
       switch (action) {
         case "up":
+          ignoreHoverRef.current = true;
           setCurrentOptionIndex(
             wrapSelection(
               currentOptionIndex,
@@ -40,6 +49,7 @@ export const TextSuggestionContent = ({
           );
           return true;
         case "down": {
+          ignoreHoverRef.current = true;
           setCurrentOptionIndex(
             wrapSelection(currentOptionIndex, 1, suggestion.suggestions.length),
           );
@@ -63,6 +73,14 @@ export const TextSuggestionContent = ({
       currentItemRef.current?.scrollIntoView({ block: "nearest" });
     }
   }, [currentOptionIndex]);
+
+  useEffect(() => {
+    const handleMouseMove = () => {
+      ignoreHoverRef.current = false;
+    };
+    document.addEventListener("mousemove", handleMouseMove);
+    return () => document.removeEventListener("mousemove", handleMouseMove);
+  }, []);
 
   // Reset the current option if the suggestions change
   useEffect(() => setCurrentOptionIndex(0), [suggestion]);
@@ -92,7 +110,11 @@ export const TextSuggestionContent = ({
                 data-index={index}
                 ref={isSelected ? currentItemRef : null}
                 onClick={() => onSelect(value)}
-                onMouseEnter={() => setCurrentOptionIndex(index)}
+                onMouseEnter={() => {
+                  if (!ignoreHoverRef.current) {
+                    setCurrentOptionIndex(index);
+                  }
+                }}
               >
                 <div class="Cql__OptionLabel">
                   {label ?? value}

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -75,8 +75,25 @@ export const TextSuggestionContent = ({
   }, [currentOptionIndex]);
 
   useEffect(() => {
-    const handleMouseMove = () => {
+    const handleMouseMove = (event: MouseEvent) => {
+      if (!ignoreHoverRef.current) {
+        return;
+      }
       ignoreHoverRef.current = false;
+
+      // The mouse may not have left the option it was already over since
+      // keyboard navigation began, in which case no further "mouseenter"
+      // will fire to select it. Select whatever option is under the pointer
+      // on this first genuine movement, so the mouse doesn't have to leave
+      // and re-enter the option to regain control.
+      const hoveredOption =
+        event.target instanceof Element
+          ? event.target.closest("[data-index]")
+          : null;
+      const hoveredIndex = hoveredOption?.getAttribute("data-index");
+      if (hoveredIndex !== null && hoveredIndex !== undefined) {
+        setCurrentOptionIndex(Number(hoveredIndex));
+      }
     };
     document.addEventListener("mousemove", handleMouseMove);
     return () => document.removeEventListener("mousemove", handleMouseMove);

--- a/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
+++ b/lib/cql/src/cqlInput/popover/components/TextSuggestionContent.tsx
@@ -27,19 +27,19 @@ export const TextSuggestionContent = ({
   const currentItemRef = useRef<HTMLDivElement | null>(null);
   const [currentOptionIndex, setCurrentOptionIndex] = useState(0);
   // Programmatically scrolling the list to keep the keyboard-selected item in
-  // view (see the effect below) moves the options underneath a stationary
-  // mouse cursor. Browsers respond to that by firing a "mouseenter" on
-  // whichever option ends up under the pointer, which would otherwise hijack
-  // keyboard navigation. We ignore hover-driven selection until the mouse
-  // physically moves again, so hovering only takes effect after a genuine
-  // mouse movement.
-  const ignoreHoverRef = useRef(false);
+  // view (see the effect below) moves the options underneath a stationary mouse
+  // cursor. Browsers respond to that by firing a "mouseenter" on whichever
+  // option ends up under the pointer, which would otherwise hijack keyboard
+  // navigation. Thus, we track our traversal mode to ignore hover-driven
+  // selection until the mouse physically moves again, so hovering only takes
+  // effect after a genuine mouse movement.
+  const isTraversingWithArrowKeys = useRef(false);
 
   useEffect(() => {
     const unsubscribe = subscribeToAction((action) => {
       switch (action) {
         case "up":
-          ignoreHoverRef.current = true;
+          isTraversingWithArrowKeys.current = true;
           setCurrentOptionIndex(
             wrapSelection(
               currentOptionIndex,
@@ -49,7 +49,7 @@ export const TextSuggestionContent = ({
           );
           return true;
         case "down": {
-          ignoreHoverRef.current = true;
+          isTraversingWithArrowKeys.current = true;
           setCurrentOptionIndex(
             wrapSelection(currentOptionIndex, 1, suggestion.suggestions.length),
           );
@@ -76,10 +76,11 @@ export const TextSuggestionContent = ({
 
   useEffect(() => {
     const handleMouseMove = (event: MouseEvent) => {
-      if (!ignoreHoverRef.current) {
+      if (!isTraversingWithArrowKeys.current) {
+        // Only run this once
         return;
       }
-      ignoreHoverRef.current = false;
+      isTraversingWithArrowKeys.current = false;
 
       // The mouse may not have left the option it was already over since
       // keyboard navigation began, in which case no further "mouseenter"
@@ -136,7 +137,7 @@ export const TextSuggestionContent = ({
                 ref={isSelected ? currentItemRef : null}
                 onClick={() => onSelect(value)}
                 onMouseEnter={() => {
-                  if (!ignoreHoverRef.current) {
+                  if (!isTraversingWithArrowKeys.current) {
                     setCurrentOptionIndex(index);
                   }
                 }}


### PR DESCRIPTION
_Co-authored by Claude._

Found a bug when mouse hovers over an item in a tall-enough-to-scroll suggestion dropdown when traversing it with arrow keys. Verified the fix in sandbox.

| Before:    | After: |
| -------- | ------- |
| <img width="350" alt="dropdown" src="https://github.com/user-attachments/assets/ef1b4e18-4a2e-4882-bfa7-01996509e9ce" />  | <img width="350" alt="after" src="https://github.com/user-attachments/assets/c0b8a6eb-d9c2-4d03-94ee-d27efb8905be" />    |

---

🤖 narrative:

## Fix keyboard navigation being hijacked by mouse hover after list auto-scroll

### Bug

In the typeahead suggestions dropdown, when the list is tall enough to scroll:

1. Hover the mouse over a suggestion
2. Use the arrow keys to navigate past the visible boundary, triggering an auto-scroll

**Actual:** the next arrow key press jumps selection to whatever option ends up under the (stationary) mouse cursor, instead of continuing the keyboard-driven traversal.

**Expected:** hovering should have no bearing on keyboard navigation. Selection should only follow the mouse after a genuine mouse movement.

### Root cause

Keyboard navigation calls `scrollIntoView` to keep the selected option in view. This moves the DOM options underneath a stationary mouse cursor, and the browser responds by firing a `mouseenter` event on whatever option now sits under the pointer — which the component was treating as a real hover, overriding the keyboard selection.

### Fix

`TextSuggestionContent` now ignores hover-driven selection changes until the mouse physically moves again. Arrow key navigation sets a flag; a `mousemove` listener clears it. A `mouseenter` fired without an intervening `mousemove` (i.e. caused by scroll, not real hover) is ignored.

### Tests

Added `TextSuggestionContent.spec.tsx` covering:
- hover alone still selects an option (baseline behaviour unaffected)
- a hover-only `mouseenter` (no `mousemove`) during keyboard navigation is ignored
- hover resumes working normally after a genuine `mousemove`

Verified TDD red/green: test fails against the old code, passes with the fix. Full suite, `eslint`, and `tsc --noEmit` all clean.