### PR TITLE
Address a few issues

### DIFF
--- a/.changeset/bright-results-stare.md
+++ b/.changeset/bright-results-stare.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Do not reset selection state on blur, fixing https://github.com/guardian/cql/issues/122

--- a/.changeset/cold-nails-push.md
+++ b/.changeset/cold-nails-push.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Add CustomElementConstructor return type to createCqlInput, fixing https://github.com/guardian/cql/issues/119

--- a/.changeset/solid-rabbits-bathe.md
+++ b/.changeset/solid-rabbits-bathe.md
@@ -1,0 +1,5 @@
+---
+"@guardian/cql": patch
+---
+
+Make description optional, https://github.com/guardian/cql/issues/120

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -38,7 +38,7 @@ export const createCqlInput = (
   config: CqlConfig = {
     syntaxHighlighting: true,
   },
-) => {
+): CustomElementConstructor => {
   class CqlInput extends HTMLElement {
     static observedAttributes = ["value", "placeholder"];
 

--- a/lib/cql/src/cqlInput/CqlInput.ts
+++ b/lib/cql/src/cqlInput/CqlInput.ts
@@ -351,7 +351,7 @@ export const createCqlInput = (
             overflow: hidden;
           }
 
-          .${CLASS_CHIP_SELECTED} {
+          .ProseMirror-focused .${CLASS_CHIP_SELECTED} {
             background-color: #334fa3;
           }
 

--- a/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.spec.ts
@@ -991,13 +991,13 @@ describe("cql plugin", () => {
       await waitFor("1: 2:");
     });
 
-    it("should clear the selection when the user blurs the input", async () => {
+    it("should not clear the selection when the user blurs the input", async () => {
       const { editor } = createCqlEditor("+tag:example");
 
       await editor.selectText("all");
       document.body.focus();
 
-      expect(editor.selection.to).toBe(1);
+      expect(editor.selection.to).toBe(editor.doc.nodeSize - 2);
     });
 
     // The selection is correct immediately after handleDoubleClick fires, but is not correct in the assertion 🤔

--- a/lib/cql/src/cqlInput/editor/plugins/cql.ts
+++ b/lib/cql/src/cqlInput/editor/plugins/cql.ts
@@ -3,7 +3,6 @@ import {
   AllSelection,
   Plugin,
   PluginKey,
-  TextSelection,
   Transaction,
 } from "prosemirror-state";
 import { Mapping } from "prosemirror-transform";
@@ -386,15 +385,6 @@ export const createCqlPlugin = ({
             return maybeAddChipAtPolarityChar(text)(view);
         }
         return false;
-      },
-      handleDOMEvents: {
-        blur: (view) => {
-          view.dispatch(
-            view.state.tr.setSelection(
-              TextSelection.near(view.state.doc.resolve(0)),
-            ),
-          );
-        },
       },
       /**
        * Handle pasting text manually, to ensure that selection state is

--- a/lib/cql/src/lang/typeahead.ts
+++ b/lib/cql/src/lang/typeahead.ts
@@ -48,7 +48,7 @@ export class TypeaheadField {
   constructor(
     public id: string,
     public name: string,
-    public description: string,
+    public description?: string,
     private resolver?: TypeaheadResolver,
     public suggestionType: SuggestionType = "TEXT",
   ) {}


### PR DESCRIPTION
## What does this change?

Addresses a few issues:

- Add CustomElementConstructor return type to createCqlInput, fixing https://github.com/guardian/cql/issues/119
- Make description optional, https://github.com/guardian/cql/issues/120
- Do not reset selection state on blur, fixing https://github.com/guardian/cql/issues/122

## How has this change been tested?

The first two are tricky to test within the library. https://github.com/guardian/cql/issues/120 is trivial. I am reasonably convinced that https://github.com/guardian/cql/issues/119 is solved, but we can 🚢  and test.

#122 is covered by unit tests. I tested the visual aspect manually to ensure chips did not remain selected on blur, as this is now handled by CSS:

<img width="668" height="140" alt="blur" src="https://github.com/user-attachments/assets/f488f0b0-6604-4b53-8146-a4b451baacdc" />
